### PR TITLE
Mode-aware recommendations: caching, ranking, and review enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Debug endpoint for raw Google Places integration.
 │   │   ├── models/               # SQLAlchemy models
 │   │   │   ├── venue.py          # Venue + VenueProfile
 │   │   │   └── user_event.py     # UserEvent + Mode/EventType enums
+│   │   ├── ranking/              # Mode-specific scoring + explanations (Step 4)
 │   │   ├── schemas/              # Pydantic schemas
 │   │   │   ├── venue.py          # VenueCreate / VenueRead
 │   │   │   └── recommend.py      # RecommendRequest, RecommendResponse, VenueCard (incl. distance_m), RecommendMeta
@@ -246,6 +247,7 @@ Debug endpoint for raw Google Places integration.
 │   │   ├── test_cache.py         # Cache key + Redis get/set (marker: cache)
 │   │   ├── test_recommend_rate_limit_and_retry.py  # Rate limit, retry, cache hit (markers: rate_limit, retry, recommend_cache)
 │   │   ├── test_google_places.py # Provider + pagination + fallback (marker: provider)
+│   │   ├── test_ranking.py       # Mode-specific ranking + explanations (Step 4)
 │   │   ├── test_schemas.py       # Schema validation (marker: schemas)
 │   │   └── test_smoke.py         # Health endpoint (marker: smoke)
 │   ├── pyproject.toml           # Pytest markers for test subsets
@@ -301,7 +303,7 @@ If Google returns HTTP 400 (e.g. due to `includedType` + `priceLevels` conflict)
 
 ### Dummy ranking (Step 2)
 
-Current ranking is a simple sort by rating (descending, nulls last) then distance (ascending). Mode-specific scoring functions are planned for Step 4.
+Step 2 started with a simple sort by rating (descending) then distance (ascending). As of **Step 4**, ranking is **mode-specific** (Work/Date/Quick Bite/Budget) and each venue includes 2–3 explanation bullets derived from the scoring factors.
 
 ### GPU-rendered map markers (GeoJSON layers)
 
@@ -384,6 +386,20 @@ The map originally used DOM-based Mapbox markers (one HTML element per venue). T
 - [x] **Measurement script** — `backend/scripts/measure_improvements.py` measures cache latency (uncached vs cached), retry success rate vs single attempt, and rate-limit 200 vs 429 counts.
 
 ### Step 4 — Baseline ranking per mode
+
+**Delivered:** Deterministic, rule-based mode scoring (Work/Date/Quick Bite/Budget) with **2–3 “Why this matches”** explanation bullets per venue.
+
+- [x] **Ranking module** — `backend/app/ranking/scoring.py` exports `score_and_explain(venue, distance_m, radius_m, mode) -> (score, explanations)`.
+- [x] **Mode-specific scoring (baseline)** — Uses a weighted sum of normalized factors:
+  - **Quick Bite:** prioritize distance + open_now, then rating, slight price preference
+  - **Work:** prioritize open_now, then distance, then rating (attribute signals come later in Step 7)
+  - **Date:** prioritize rating + distance + mid-range price preference
+  - **Budget:** prioritize low price + “value” (rating × cheapness), then distance
+- [x] **Explanations tied to the score** — Bullets are selected from the top contributing scoring factors (e.g. “Within 450 m”, “Open now”, “Highly rated (4.6)”, “Budget-friendly”, “Great value”, “Mid-range pricing”).
+- [x] **Wired into `/recommend`** — `backend/app/main.py` scores each candidate venue, sorts by score, and includes `explanations` on each `VenueCard`.
+- [x] **Unit tests** — `backend/tests/test_ranking.py` covers deterministic output, mode-specific ordering properties, explanation behavior, and edge cases (missing rating/price/hours).
+
+**Scoring details:** See `backend/app/ranking/README.md` for the exact normalization and per-mode equations.
 
 ### Step 5 — Reviews ingestion + text inference
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,12 +12,15 @@ from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
 
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from app.cache import build_recommend_cache_key, get_cached_recommend, set_cached_recommend
 from app.config import settings
+from app.db.session import get_db
 from app.models.user_event import Mode
 from app.ranking import score_and_explain
 from app.schemas.recommend import RecommendMeta, RecommendRequest, RecommendResponse, VenueCard
-from app.schemas.venue import VenueCreate
+from app.schemas.venue import VenueCreate, VenueProfileResponse
 
 logger = logging.getLogger(__name__)
 limiter = Limiter(key_func=get_remote_address)
@@ -169,6 +172,38 @@ def health():
 def hello():
     """Hello endpoint."""
     return {"message": "hello"}
+
+
+@app.get("/venues/{provider_id}/profile", response_model=VenueProfileResponse)
+async def get_venue_profile(
+    provider_id: str,
+    session: AsyncSession = Depends(get_db),
+):
+    """Return enriched attribute profile for a venue.
+
+    Triggers heuristic enrichment (reviews → attribute scores + evidence
+    snippets) if the profile is missing or older than the TTL.  Returns
+    immediately when the profile is already fresh.
+
+    Args:
+        provider_id: Google Places place ID (e.g. ``ChIJ...``).
+
+    Returns:
+        VenueProfileResponse with attribute_scores and evidence_snippets.
+    """
+    from app.services.enrichment import enrich_venue_profile
+
+    try:
+        return await enrich_venue_profile(provider_id, session)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except httpx.HTTPStatusError as e:
+        detail = e.response.text if e.response else str(e)
+        logger.error("Provider error enriching venue %s: %s", provider_id, detail)
+        raise HTTPException(status_code=502, detail=f"Provider error: {detail}") from e
+    except Exception as e:
+        logger.error("Unexpected error enriching venue %s: %s", provider_id, e)
+        raise HTTPException(status_code=500, detail="Enrichment failed") from e
 
 
 @app.get("/test/google-places")
@@ -330,7 +365,7 @@ async def recommend(
 
         cards = [
             _venue_create_to_card(v, distance_m=dist_m, explanations=explanations)
-            for v, dist_m, _score, explanations in ranked[:20]
+            for v, dist_m, _score, explanations in ranked[:max_results]
         ]
         total = len(cards)
         elapsed_ms = int((time.perf_counter() - t0_fetch) * 1000)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,7 +11,6 @@ from fastapi.middleware.cors import CORSMiddleware
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
-
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.cache import build_recommend_cache_key, get_cached_recommend, set_cached_recommend

--- a/backend/app/providers/__init__.py
+++ b/backend/app/providers/__init__.py
@@ -1,5 +1,5 @@
 """Google Places provider package."""
 
-from app.providers.google import GooglePlacesClient
+from app.providers.google import GooglePlacesClient, ReviewSnippet
 
-__all__ = ["GooglePlacesClient"]
+__all__ = ["GooglePlacesClient", "ReviewSnippet"]

--- a/backend/app/providers/google.py
+++ b/backend/app/providers/google.py
@@ -1,6 +1,7 @@
 """Google Places API client using Text Search (New)."""
 
 import logging
+from dataclasses import dataclass
 
 import httpx
 
@@ -21,6 +22,30 @@ FIELD_MASK = (
     "places.regularOpeningHours,"
     "nextPageToken"
 )
+
+# Field mask for Place Details (single place lookup — no "places." prefix)
+DETAILS_FIELD_MASK = (
+    "id,"
+    "displayName,"
+    "location,"
+    "rating,"
+    "priceLevel,"
+    "types,"
+    "formattedAddress,"
+    "currentOpeningHours,"
+    "regularOpeningHours"
+)
+
+# Field mask for fetching review text and editorial summary only
+REVIEWS_FIELD_MASK = "reviews,editorialSummary"
+
+
+@dataclass
+class ReviewSnippet:
+    """A single text snippet from a venue's reviews or editorial summary."""
+
+    text: str
+    rating: float | None = None
 
 PRICE_INT_TO_API = {
     0: "PRICE_LEVEL_FREE",
@@ -196,6 +221,81 @@ class GooglePlacesClient:
             page + 1,
         )
         return venues
+
+    async def fetch_place_details(self, provider_place_id: str) -> VenueCreate | None:
+        """Fetch basic venue details for a single place by its provider ID.
+
+        Uses the Place Details (New) endpoint:
+          GET https://places.googleapis.com/v1/places/{place_id}
+
+        Args:
+            provider_place_id: The Google Places place ID.
+
+        Returns:
+            VenueCreate schema on success, or None if the place can't be normalized.
+        """
+        url = f"https://places.googleapis.com/v1/places/{provider_place_id}"
+        headers = {
+            "X-Goog-Api-Key": self.api_key,
+            "X-Goog-FieldMask": DETAILS_FIELD_MASK,
+        }
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.get(url, headers=headers)
+            response.raise_for_status()
+            data = response.json()
+        return self._normalize_place(data)
+
+    async def fetch_place_reviews(
+        self,
+        provider_place_id: str,
+        max_snippets: int = 10,
+    ) -> list[ReviewSnippet]:
+        """Fetch review snippets and editorial summary for a single place.
+
+        Returns up to ``max_snippets`` short text excerpts suitable for
+        heuristic attribute inference.  The editorial summary (when present)
+        is prepended so it is always considered by the pipeline.
+
+        Args:
+            provider_place_id: The Google Places place ID.
+            max_snippets: Maximum total snippets to return.
+
+        Returns:
+            List of ReviewSnippet objects (may be empty if none are available).
+        """
+        url = f"https://places.googleapis.com/v1/places/{provider_place_id}"
+        headers = {
+            "X-Goog-Api-Key": self.api_key,
+            "X-Goog-FieldMask": REVIEWS_FIELD_MASK,
+        }
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.get(url, headers=headers)
+            response.raise_for_status()
+            data = response.json()
+
+        snippets: list[ReviewSnippet] = []
+
+        # Editorial summary (one per place, no rating)
+        editorial = data.get("editorialSummary") or {}
+        editorial_text = editorial.get("text", "").strip()
+        if editorial_text:
+            snippets.append(ReviewSnippet(text=editorial_text[:300]))
+
+        # Review texts (up to 5 from Google)
+        for review in data.get("reviews", []):
+            text_obj = review.get("text") or {}
+            text = (text_obj.get("text") or "").strip() if isinstance(text_obj, dict) else ""
+            if not text:
+                continue
+            rating = review.get("rating")
+            snippets.append(ReviewSnippet(text=text[:300], rating=rating))
+            if len(snippets) >= max_snippets:
+                break
+
+        logger.debug(
+            "fetch_place_reviews(%s): %d snippets returned", provider_place_id, len(snippets)
+        )
+        return snippets[:max_snippets]
 
     # Keep backward-compatible alias for test endpoint
     async def search_nearby(

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service layer: business logic that coordinates DB, providers, and analysis."""

--- a/backend/app/services/enrichment.py
+++ b/backend/app/services/enrichment.py
@@ -16,8 +16,7 @@ refactoring the core logic.
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timedelta, timezone
-from uuid import UUID
+from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -92,7 +91,7 @@ async def enrich_venue_profile(
     )
 
     # Upsert VenueProfile
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     expires_at = now + timedelta(days=ttl_days)
 
     if venue.profile:
@@ -136,7 +135,7 @@ async def _get_or_create_venue(provider_id: str, session: AsyncSession) -> Venue
     if not venue_create:
         raise ValueError(f"Place not found in provider: {provider_id}")
 
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     venue = Venue(
         provider_id=venue_create.provider_id,
         provider_name=venue_create.provider_name,
@@ -167,5 +166,5 @@ def _is_fresh(profile: VenueProfile | None, ttl_days: int) -> bool:
     if profiled is None:
         return False
     if profiled.tzinfo is None:
-        profiled = profiled.replace(tzinfo=timezone.utc)
-    return (datetime.now(timezone.utc) - profiled) < timedelta(days=ttl_days)
+        profiled = profiled.replace(tzinfo=UTC)
+    return (datetime.now(UTC) - profiled) < timedelta(days=ttl_days)

--- a/backend/app/services/enrichment.py
+++ b/backend/app/services/enrichment.py
@@ -1,0 +1,171 @@
+"""
+Venue enrichment service.
+
+enrich_venue_profile(provider_id, session)
+  1. Locate the Venue in DB by provider_id; if absent, fetch details from
+     Google Places and create the record.
+  2. Check whether the existing VenueProfile is fresh (within TTL).
+  3. If stale or missing: call Google Places reviews endpoint, run heuristic
+     text analysis, then upsert VenueProfile.
+  4. Return the current VenueProfileResponse.
+
+This function is designed so that Step 6 can wrap it in a Celery task without
+refactoring the core logic.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.venue import Venue, VenueProfile
+from app.providers.google import GooglePlacesClient
+from app.schemas.venue import VenueProfileResponse
+from app.text_attributes.heuristics import infer_attributes_from_text
+
+logger = logging.getLogger(__name__)
+
+# Profiles older than this are considered stale and will be re-inferred.
+PROFILE_TTL_DAYS = 7
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def enrich_venue_profile(
+    provider_id: str,
+    session: AsyncSession,
+    ttl_days: int = PROFILE_TTL_DAYS,
+) -> VenueProfileResponse:
+    """Enrich a venue with heuristic attribute scores derived from its reviews.
+
+    If the venue is not yet in the DB it is created automatically from the
+    Google Places Details API.  If the profile already exists and is within
+    ``ttl_days`` days of its ``profiled_at`` timestamp it is returned as-is.
+
+    Args:
+        provider_id: Google Places place ID (matches Venue.provider_id).
+        session: Active async SQLAlchemy session.
+        ttl_days: Number of days before a profile is considered stale.
+
+    Returns:
+        VenueProfileResponse with the current (or freshly computed) profile.
+
+    Raises:
+        ValueError: If the place cannot be found via the provider API.
+        httpx.HTTPStatusError: If the provider API returns an error.
+    """
+    venue = await _get_or_create_venue(provider_id, session)
+
+    # Re-load with profile relationship to avoid lazy-load issues
+    result = await session.execute(
+        select(Venue).where(Venue.id == venue.id).options(selectinload(Venue.profile))
+    )
+    venue = result.scalars().one()
+
+    if _is_fresh(venue.profile, ttl_days):
+        logger.debug("enrich_venue_profile(%s): profile is fresh, skipping", provider_id)
+        return VenueProfileResponse.model_validate(venue.profile)
+
+    logger.info("enrich_venue_profile(%s): enriching venue", provider_id)
+
+    # Fetch review snippets from provider
+    client = GooglePlacesClient()
+    snippets = await client.fetch_place_reviews(provider_id)
+    texts = [s.text for s in snippets]
+
+    # Run heuristic text pipeline
+    scores, evidence = infer_attributes_from_text(texts)
+
+    logger.debug(
+        "enrich_venue_profile(%s): inferred %d attributes from %d snippets",
+        provider_id,
+        len(scores),
+        len(texts),
+    )
+
+    # Upsert VenueProfile
+    now = datetime.now(timezone.utc)
+    expires_at = now + timedelta(days=ttl_days)
+
+    if venue.profile:
+        venue.profile.attribute_scores = scores
+        venue.profile.evidence_snippets = evidence
+        venue.profile.profiled_at = now
+        venue.profile.expires_at = expires_at
+    else:
+        profile = VenueProfile(
+            venue_id=venue.id,
+            attribute_scores=scores,
+            evidence_snippets=evidence,
+            profiled_at=now,
+            expires_at=expires_at,
+        )
+        session.add(profile)
+        venue.profile = profile
+
+    await session.commit()
+    await session.refresh(venue.profile)
+    return VenueProfileResponse.model_validate(venue.profile)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+async def _get_or_create_venue(provider_id: str, session: AsyncSession) -> Venue:
+    """Return an existing Venue or create one from Google Places Details."""
+    result = await session.execute(
+        select(Venue).where(Venue.provider_id == provider_id)
+    )
+    venue = result.scalars().first()
+    if venue:
+        return venue
+
+    # Venue is not in DB yet — fetch basic info from Google Places Details
+    client = GooglePlacesClient()
+    venue_create = await client.fetch_place_details(provider_id)
+    if not venue_create:
+        raise ValueError(f"Place not found in provider: {provider_id}")
+
+    now = datetime.now(timezone.utc)
+    venue = Venue(
+        provider_id=venue_create.provider_id,
+        provider_name=venue_create.provider_name,
+        name=venue_create.name,
+        categories=venue_create.categories,
+        lat=venue_create.lat,
+        lng=venue_create.lng,
+        address=venue_create.address,
+        rating=venue_create.rating,
+        price_level=venue_create.price_level,
+        hours=venue_create.hours,
+        raw_hours=venue_create.raw_hours,
+        last_seen_at=now,
+        created_at=now,
+        updated_at=now,
+    )
+    session.add(venue)
+    await session.flush()  # Populate venue.id before profile FK is set
+    logger.info("enrich_venue_profile: created venue %s (%s)", venue.name, provider_id)
+    return venue
+
+
+def _is_fresh(profile: VenueProfile | None, ttl_days: int) -> bool:
+    """Return True if the profile exists and was profiled within ttl_days."""
+    if profile is None:
+        return False
+    profiled = profile.profiled_at
+    if profiled is None:
+        return False
+    if profiled.tzinfo is None:
+        profiled = profiled.replace(tzinfo=timezone.utc)
+    return (datetime.now(timezone.utc) - profiled) < timedelta(days=ttl_days)

--- a/backend/app/text_attributes/__init__.py
+++ b/backend/app/text_attributes/__init__.py
@@ -1,0 +1,5 @@
+"""Text attribute inference for venues. See heuristics.py for design."""
+
+from app.text_attributes.heuristics import ATTRIBUTE_RULES, infer_attributes_from_text
+
+__all__ = ["ATTRIBUTE_RULES", "infer_attributes_from_text"]

--- a/backend/app/text_attributes/heuristics.py
+++ b/backend/app/text_attributes/heuristics.py
@@ -1,0 +1,234 @@
+"""
+Heuristic text-attribute inference for venues.
+
+Infers per-venue attribute scores (0–1) and evidence snippets from a list of
+short text snippets (reviews, editorial summaries, etc.) using deterministic
+keyword/substring rules — no ML or external dependencies required.
+
+## Scoring formula
+
+For each attribute:
+    score = pos_count / (pos_count + neg_count + 1)
+
+Where:
+  - pos_count: number of snippets matching at least one positive pattern
+  - neg_count: number of snippets matching at least one negative pattern
+  - The +1 denominator prevents 1.0 with a single weak signal
+
+Score ranges:
+  - 0.0           : no signal (attribute is omitted from the output dict)
+  - 0.0 – ~0.33   : negative signal dominates
+  - ~0.33 – ~0.67 : mixed / weak signal
+  - ~0.67 – 1.0   : positive signal dominates
+
+## Upgrade path
+
+To replace or augment with ML, swap out this module while keeping the same
+public interface:  infer_attributes_from_text(snippets) -> (scores, evidence)
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Canonical attribute set and their keyword rules
+# ---------------------------------------------------------------------------
+
+# Each entry: attribute_name -> (positive_patterns, negative_patterns)
+# Patterns are matched case-insensitively as substrings.
+# Order within each list does not affect scoring.
+ATTRIBUTE_RULES: dict[str, tuple[list[str], list[str]]] = {
+    "quiet": (
+        [
+            "quiet",
+            "peaceful",
+            "calm",
+            "tranquil",
+            "not too loud",
+            "serene",
+            "relaxing atmosphere",
+            "mellow vibe",
+            "low-key",
+        ],
+        [
+            "loud",
+            "noisy",
+            "crowded",
+            "packed",
+            "blasting music",
+            "rowdy",
+            "bustling",
+            "chaotic",
+            "deafening",
+        ],
+    ),
+    "laptop_friendly": (
+        [
+            "wifi",
+            "wi-fi",
+            "wi fi",
+            "power outlet",
+            "power outlets",
+            "outlets",
+            "sockets",
+            "plugs",
+            "good for work",
+            "study",
+            "laptop",
+            "working",
+            "coworking",
+            "remote work",
+            "great for studying",
+        ],
+        [
+            "no wifi",
+            "no outlets",
+            "no laptops",
+            "time limit",
+            "no working",
+        ],
+    ),
+    "romantic": (
+        [
+            "romantic",
+            "date night",
+            "candlelit",
+            "candle",
+            "cozy",
+            "intimate",
+            "ambience",
+            "atmosphere",
+            "anniversary",
+            "special occasion",
+            "date spot",
+            "lovely setting",
+            "charming",
+        ],
+        [
+            "rowdy",
+            "sports bar",
+            "family with kids",
+            "boisterous",
+            "frat",
+            "college bar",
+        ],
+    ),
+    "fast_service": (
+        [
+            "fast service",
+            "quick service",
+            "came out quickly",
+            "prompt",
+            "no wait",
+            "short wait",
+            "speedy service",
+            "quick turnaround",
+            "served quickly",
+            "fast food",
+        ],
+        [
+            "slow service",
+            "took forever",
+            "long wait",
+            "waited",
+            "slow",
+            "sluggish",
+            "understaffed",
+        ],
+    ),
+    "value": (
+        [
+            "good value",
+            "worth the price",
+            "affordable",
+            "cheap",
+            "great deal",
+            "value for money",
+            "reasonably priced",
+            "budget friendly",
+            "inexpensive",
+        ],
+        [
+            "overpriced",
+            "not worth",
+            "ripoff",
+            "rip off",
+            "too expensive",
+        ],
+    ),
+}
+
+# Maximum number of evidence snippets to keep per attribute
+MAX_EVIDENCE_PER_ATTRIBUTE = 3
+
+# Maximum characters per evidence snippet shown to users
+EVIDENCE_MAX_CHARS = 160
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def infer_attributes_from_text(
+    snippets: list[str],
+) -> tuple[dict[str, float], dict[str, list[str]]]:
+    """Infer venue attributes from a list of text snippets.
+
+    Applies keyword/rule heuristics for each attribute in ATTRIBUTE_RULES.
+    Attributes with no signal are omitted from the returned dicts.
+
+    Args:
+        snippets: List of short text strings (reviews, editorial summaries,
+            etc.). Empty strings are ignored.
+
+    Returns:
+        A tuple of:
+          - attribute_scores: dict mapping attribute name -> score in [0, 1].
+            Omitted if no positive or negative patterns matched.
+          - evidence_snippets: dict mapping attribute name -> list of
+            truncated snippets that contained a positive pattern match.
+    """
+    if not snippets:
+        return {}, {}
+
+    pos_counts: dict[str, int] = {attr: 0 for attr in ATTRIBUTE_RULES}
+    neg_counts: dict[str, int] = {attr: 0 for attr in ATTRIBUTE_RULES}
+    evidence: dict[str, list[str]] = {attr: [] for attr in ATTRIBUTE_RULES}
+
+    for snippet in snippets:
+        if not snippet or not snippet.strip():
+            continue
+        lowered = snippet.lower()
+        for attr, (pos_patterns, neg_patterns) in ATTRIBUTE_RULES.items():
+            matched_neg = any(p in lowered for p in neg_patterns)
+            # Only count as positive when the snippet isn't also a negation
+            # (e.g. "no wifi" contains "wifi" but should not be a positive hit)
+            matched_pos = (not matched_neg) and any(p in lowered for p in pos_patterns)
+
+            if matched_pos:
+                pos_counts[attr] += 1
+                if len(evidence[attr]) < MAX_EVIDENCE_PER_ATTRIBUTE:
+                    evidence[attr].append(_truncate(snippet))
+            if matched_neg:
+                neg_counts[attr] += 1
+
+    scores: dict[str, float] = {}
+    for attr in ATTRIBUTE_RULES:
+        pos = pos_counts[attr]
+        neg = neg_counts[attr]
+        if pos + neg == 0:
+            continue  # No signal; attribute is not included in output
+        scores[attr] = pos / (pos + neg + 1)
+
+    # Only return evidence for attributes that had positive signal
+    clean_evidence = {attr: evs for attr, evs in evidence.items() if evs}
+
+    return scores, clean_evidence
+
+
+def _truncate(text: str, max_chars: int = EVIDENCE_MAX_CHARS) -> str:
+    """Truncate text to max_chars, appending '…' if needed."""
+    text = text.strip()
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars].rstrip() + "…"

--- a/backend/tests/test_text_attributes_heuristics.py
+++ b/backend/tests/test_text_attributes_heuristics.py
@@ -8,14 +8,12 @@ Tests cover:
 - Edge cases: empty inputs, conflicting signals, all-negative, no signal.
 """
 
-import pytest
 
 from app.text_attributes.heuristics import (
     ATTRIBUTE_RULES,
     EVIDENCE_MAX_CHARS,
     infer_attributes_from_text,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/backend/tests/test_text_attributes_heuristics.py
+++ b/backend/tests/test_text_attributes_heuristics.py
@@ -1,0 +1,239 @@
+"""Unit tests for heuristic text-attribute inference.
+
+Tests cover:
+- Scoring direction for each attribute (positive patterns → high score,
+  negative patterns → low score).
+- Evidence snippet content and truncation.
+- Score range guarantees (0–1).
+- Edge cases: empty inputs, conflicting signals, all-negative, no signal.
+"""
+
+import pytest
+
+from app.text_attributes.heuristics import (
+    ATTRIBUTE_RULES,
+    EVIDENCE_MAX_CHARS,
+    infer_attributes_from_text,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def snippets_with(*phrases: str) -> list[str]:
+    """Wrap phrases in sentence-like snippets."""
+    return [f"This place is really {p} in every way." for p in phrases]
+
+
+# ---------------------------------------------------------------------------
+# Basic shape
+# ---------------------------------------------------------------------------
+
+
+def test_returns_empty_on_no_snippets():
+    scores, evidence = infer_attributes_from_text([])
+    assert scores == {}
+    assert evidence == {}
+
+
+def test_returns_empty_on_blank_snippets():
+    scores, evidence = infer_attributes_from_text(["", "   ", "\n"])
+    assert scores == {}
+    assert evidence == {}
+
+
+def test_scores_in_range():
+    texts = snippets_with("quiet", "laptop", "romantic", "fast service", "affordable")
+    scores, _ = infer_attributes_from_text(texts)
+    for attr, score in scores.items():
+        assert 0.0 <= score <= 1.0, f"{attr} score {score} out of range"
+
+
+def test_all_canonical_attributes_covered():
+    """ATTRIBUTE_RULES contains all expected attributes."""
+    expected = {"quiet", "laptop_friendly", "romantic", "fast_service", "value"}
+    assert set(ATTRIBUTE_RULES.keys()) == expected
+
+
+# ---------------------------------------------------------------------------
+# quiet
+# ---------------------------------------------------------------------------
+
+
+def test_quiet_positive_patterns_raise_score():
+    texts = ["The place is so quiet and peaceful.", "Very calm and tranquil atmosphere."]
+    scores, _ = infer_attributes_from_text(texts)
+    assert "quiet" in scores
+    assert scores["quiet"] > 0.4
+
+
+def test_quiet_negative_patterns_lower_score():
+    texts = ["So loud and noisy in here.", "Very crowded and rowdy."]
+    scores, _ = infer_attributes_from_text(texts)
+    assert "quiet" in scores
+    assert scores["quiet"] < 0.4
+
+
+def test_quiet_mixed_signals():
+    texts = [
+        "Generally peaceful but can get loud on weekends.",
+        "Quiet during the week, noisy and crowded on Fridays.",
+    ]
+    scores, _ = infer_attributes_from_text(texts)
+    assert "quiet" in scores
+    # Both positive and negative matched — score should be somewhere in the middle
+    assert 0.0 <= scores["quiet"] <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# laptop_friendly
+# ---------------------------------------------------------------------------
+
+
+def test_laptop_friendly_raises_on_positive():
+    texts = ["Great wifi and power outlets throughout.", "Perfect for studying with your laptop."]
+    scores, _ = infer_attributes_from_text(texts)
+    assert "laptop_friendly" in scores
+    assert scores["laptop_friendly"] > 0.4
+
+
+def test_laptop_friendly_lowers_on_negative():
+    texts = ["No wifi available here.", "No outlets anywhere, very frustrating."]
+    scores, _ = infer_attributes_from_text(texts)
+    assert "laptop_friendly" in scores
+    assert scores["laptop_friendly"] < 0.4
+
+
+# ---------------------------------------------------------------------------
+# romantic
+# ---------------------------------------------------------------------------
+
+
+def test_romantic_raises_on_positive():
+    texts = ["Very romantic and intimate setting.", "Perfect for a date night — cozy and charming."]
+    scores, _ = infer_attributes_from_text(texts)
+    assert "romantic" in scores
+    assert scores["romantic"] > 0.4
+
+
+def test_romantic_lowers_on_negative():
+    texts = ["Rowdy sports bar.", "Loud college bar, not a date spot."]
+    scores, _ = infer_attributes_from_text(texts)
+    assert "romantic" in scores
+    assert scores["romantic"] < 0.4
+
+
+# ---------------------------------------------------------------------------
+# fast_service
+# ---------------------------------------------------------------------------
+
+
+def test_fast_service_raises_on_positive():
+    texts = ["Incredibly fast service.", "Food came out quickly with no wait."]
+    scores, _ = infer_attributes_from_text(texts)
+    assert "fast_service" in scores
+    assert scores["fast_service"] > 0.4
+
+
+def test_fast_service_lowers_on_slow():
+    texts = ["Slow service — waited 45 minutes.", "Took forever to get our order."]
+    scores, _ = infer_attributes_from_text(texts)
+    assert "fast_service" in scores
+    assert scores["fast_service"] < 0.4
+
+
+# ---------------------------------------------------------------------------
+# value
+# ---------------------------------------------------------------------------
+
+
+def test_value_raises_on_positive():
+    texts = ["Great value for money.", "Very affordable and reasonably priced."]
+    scores, _ = infer_attributes_from_text(texts)
+    assert "value" in scores
+    assert scores["value"] > 0.4
+
+
+def test_value_lowers_on_negative():
+    texts = ["Totally overpriced.", "Not worth the price — ripoff."]
+    scores, _ = infer_attributes_from_text(texts)
+    assert "value" in scores
+    assert scores["value"] < 0.4
+
+
+# ---------------------------------------------------------------------------
+# Ordering across multiple mentions
+# ---------------------------------------------------------------------------
+
+
+def test_more_positive_mentions_gives_higher_score():
+    """Attribute mentioned in more snippets → higher score."""
+    texts_few = ["quiet atmosphere"] * 1 + ["unrelated"] * 5
+    texts_many = ["quiet atmosphere"] * 5 + ["unrelated"] * 1
+
+    scores_few, _ = infer_attributes_from_text(texts_few)
+    scores_many, _ = infer_attributes_from_text(texts_many)
+
+    assert scores_many.get("quiet", 0) > scores_few.get("quiet", 0)
+
+
+# ---------------------------------------------------------------------------
+# Evidence snippets
+# ---------------------------------------------------------------------------
+
+
+def test_evidence_contains_matching_text():
+    texts = ["Great wifi here for working.", "Plenty of power outlets available."]
+    _, evidence = infer_attributes_from_text(texts)
+    assert "laptop_friendly" in evidence
+    assert len(evidence["laptop_friendly"]) >= 1
+    # Evidence should contain the snippet text (possibly truncated)
+    combined = " ".join(evidence["laptop_friendly"])
+    assert "wifi" in combined.lower() or "outlet" in combined.lower()
+
+
+def test_evidence_capped_at_max():
+    """No more than MAX_EVIDENCE_PER_ATTRIBUTE snippets per attribute."""
+    texts = [f"quiet and peaceful visit number {i}" for i in range(20)]
+    _, evidence = infer_attributes_from_text(texts)
+    assert "quiet" in evidence
+    assert len(evidence["quiet"]) <= 3
+
+
+def test_evidence_truncated_to_max_chars():
+    long_text = "quiet " + "x" * (EVIDENCE_MAX_CHARS + 50)
+    _, evidence = infer_attributes_from_text([long_text])
+    for snippets in evidence.values():
+        for s in snippets:
+            assert len(s) <= EVIDENCE_MAX_CHARS + 1  # +1 for the ellipsis char
+
+
+def test_evidence_only_for_attributes_with_positive_signal():
+    """Evidence dict must not include attributes that had only negative matches."""
+    texts = ["So loud and noisy."]  # negative for 'quiet', no positive
+    _, evidence = infer_attributes_from_text(texts)
+    assert "quiet" not in evidence
+
+
+# ---------------------------------------------------------------------------
+# Attributes with no signal are omitted
+# ---------------------------------------------------------------------------
+
+
+def test_attributes_without_signal_absent_from_scores():
+    texts = ["The food was delicious and the service was excellent."]
+    scores, _ = infer_attributes_from_text(texts)
+    # None of our attribute keywords appear → empty scores
+    assert scores == {}
+
+
+def test_only_matched_attributes_in_scores():
+    texts = ["Great wifi here for studying."]
+    scores, _ = infer_attributes_from_text(texts)
+    # Only laptop_friendly should have a signal
+    assert "laptop_friendly" in scores
+    # Other attributes should NOT appear (no signal)
+    for attr in ["quiet", "romantic", "fast_service", "value"]:
+        assert attr not in scores

--- a/frontend/components/VenueDetailPanel.tsx
+++ b/frontend/components/VenueDetailPanel.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { type RecommendVenue } from "@/lib/api";
+import { useEffect, useState } from "react";
+
+import { getVenueProfile, type VenueProfile, type RecommendVenue } from "@/lib/api";
 
 interface VenueDetailPanelProps {
   venue: RecommendVenue;
@@ -44,7 +46,64 @@ function DirectionsLink({ lat, lng, name }: { lat: number; lng: number; name: st
   );
 }
 
+/** Display label + icon for each canonical attribute key. */
+const ATTRIBUTE_META: Record<string, { label: string; icon: string }> = {
+  quiet: { label: "Quiet", icon: "🤫" },
+  laptop_friendly: { label: "Laptop-friendly", icon: "💻" },
+  romantic: { label: "Romantic", icon: "✨" },
+  fast_service: { label: "Quick service", icon: "⚡" },
+  value: { label: "Good value", icon: "💰" },
+};
+
+/** Minimum score to display an attribute tag (avoids showing very weak signals). */
+const SCORE_THRESHOLD = 0.4;
+
+function AttributeTags({ profile }: { profile: VenueProfile }) {
+  const visible = Object.entries(profile.attribute_scores)
+    .filter(([, score]) => score >= SCORE_THRESHOLD)
+    .sort(([, a], [, b]) => b - a);
+
+  if (visible.length === 0) return null;
+
+  return (
+    <div className="mt-4">
+      <h3 className="text-xs font-semibold uppercase tracking-wide text-zinc-400 dark:text-zinc-500">
+        Vibe
+      </h3>
+      <div className="mt-2 flex flex-wrap gap-2">
+        {visible.map(([attr, score]) => {
+          const meta = ATTRIBUTE_META[attr] ?? { label: attr, icon: "•" };
+          const evidence = profile.evidence_snippets[attr]?.[0];
+          return (
+            <div key={attr} className="group relative">
+              <span className="inline-flex cursor-default items-center gap-1 rounded-full bg-blue-50 px-2.5 py-1 text-xs font-medium text-blue-700 ring-1 ring-blue-200 dark:bg-blue-950/40 dark:text-blue-300 dark:ring-blue-800">
+                <span>{meta.icon}</span>
+                {meta.label}
+                <span className="ml-0.5 text-blue-400 dark:text-blue-500">
+                  {Math.round(score * 100)}%
+                </span>
+              </span>
+              {evidence && (
+                <div className="pointer-events-none absolute bottom-full left-0 z-10 mb-1.5 hidden w-56 rounded-md border border-zinc-200 bg-white p-2 text-xs text-zinc-600 shadow-lg group-hover:block dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400">
+                  &ldquo;{evidence}&rdquo;
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 export default function VenueDetailPanel({ venue, rank, onClose }: VenueDetailPanelProps) {
+  const [profile, setProfile] = useState<VenueProfile | null>(null);
+
+  useEffect(() => {
+    setProfile(null);
+    getVenueProfile(venue.provider_id).then(setProfile).catch(() => setProfile(null));
+  }, [venue.provider_id]);
+
   const weekdayText = (venue.hours as { weekday_text?: string[] } | null)?.weekday_text;
   const distanceLabel =
     venue.distance_m != null
@@ -142,7 +201,7 @@ export default function VenueDetailPanel({ venue, rank, onClose }: VenueDetailPa
           </div>
         )}
 
-        {/* Explanations (placeholder for Step 4 mode-specific scoring) */}
+        {/* Explanations from mode-specific scoring (Step 4) */}
         {venue.explanations && venue.explanations.length > 0 && (
           <div className="mt-4">
             <h3 className="text-xs font-semibold uppercase tracking-wide text-zinc-400 dark:text-zinc-500">
@@ -158,6 +217,9 @@ export default function VenueDetailPanel({ venue, rank, onClose }: VenueDetailPa
             </ul>
           </div>
         )}
+
+        {/* Heuristic attribute tags + evidence (Step 5) */}
+        {profile && <AttributeTags profile={profile} />}
       </div>
     </div>
   );

--- a/frontend/components/VenueDetailPanel.tsx
+++ b/frontend/components/VenueDetailPanel.tsx
@@ -100,7 +100,6 @@ export default function VenueDetailPanel({ venue, rank, onClose }: VenueDetailPa
   const [profile, setProfile] = useState<VenueProfile | null>(null);
 
   useEffect(() => {
-    setProfile(null);
     getVenueProfile(venue.provider_id).then(setProfile).catch(() => setProfile(null));
   }, [venue.provider_id]);
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -98,6 +98,31 @@ export interface RecommendResponse {
     venues: RecommendVenue[]
 }
 
+export interface VenueProfile {
+    id: string;
+    venue_id: string;
+    attribute_scores: Record<string, number>;
+    evidence_snippets: Record<string, string[]>;
+    embedding_ref: string | null;
+    profiled_at: string;
+    expires_at: string | null;
+}
+
+/**
+ * Fetch (and trigger, if stale) the enriched attribute profile for a venue.
+ * Returns null on any error so callers can degrade gracefully.
+ */
+export async function getVenueProfile(providerId: string): Promise<VenueProfile | null> {
+    if (!API_URL) return null;
+    try {
+        const response = await fetch(`${API_URL}/venues/${encodeURIComponent(providerId)}/profile`);
+        if (!response.ok) return null;
+        return (await response.json()) as VenueProfile;
+    } catch {
+        return null;
+    }
+}
+
 export async function recommend(params: RecommendParams): Promise<RecommendResponse> {
     if (!API_URL) {
         throw new Error("API_URL is not defined");


### PR DESCRIPTION
## Summary
- Adds Step 3 `/recommend` hardening: Redis caching, Haversine distance, open-now filtering, rate limiting, and provider retry/backoff.
- Adds Step 4 baseline mode ranking with deterministic scoring and "Why this matches" explanations for Work, Date, Quick Bite, and Budget.
- Adds Step 5 heuristic review enrichment: Google review ingestion, keyword-based attribute inference, `VenueProfile` upserts, `GET /venues/{provider_id}/profile`, and detail-panel vibe tags with evidence tooltips.

## Test plan
- [ ] `cd backend && python3 -m pytest tests/test_ranking.py tests/test_text_attributes_heuristics.py -v`
- [ ] `cd backend && python3 -m pytest tests/test_cache.py tests/test_recommend_rate_limit_and_retry.py -v`
- [ ] Start backend + frontend locally and verify `/recommend` returns ranked venues with explanations
- [ ] Open a venue detail panel and confirm vibe tags load from `/venues/{provider_id}/profile`
- [ ] Confirm cached `/recommend` responses include ranked order and explanations


Made with [Cursor](https://cursor.com)