### PR TITLE
Step 6: Async enrichment jobs + Step 5 hardening

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -8,6 +8,21 @@ jobs:
   backend:
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: modemap_test
+          POSTGRES_USER: modemap
+          POSTGRES_PASSWORD: modemap
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd "pg_isready -U modemap -d modemap_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - uses: actions/checkout@v4
 
@@ -27,6 +42,8 @@ jobs:
           ruff check .
 
       - name: Tests
+        env:
+          TEST_DATABASE_URL: postgresql+psycopg://modemap:modemap@localhost:5433/modemap_test
         run: |
           cd backend
           pytest

--- a/README.md
+++ b/README.md
@@ -17,12 +17,11 @@ Instead of returning a generic list of nearby venues, ModeMap lets users choose 
 | **Budget** | Cheap eats, high-value spots | `"affordable restaurant or cheap eats"` |
 
 ### Explicitly Out of Scope (for MVP)
-- Machine learning models
-- Review text inference
+- Machine learning models (Hugging Face classifiers/embeddings — Step 7+)
 - Personalization
-- Async enrichment pipelines
+- Frontend job status dashboard (admin JSON API only for Step 6)
 
-All ranking logic is deterministic and rule-based in early stages.
+Heuristic review-based attribute inference (keyword rules, no ML) is in scope as of **Step 5**. Background Celery enrichment orchestration is in scope as of **Step 6**. All ranking logic remains deterministic and rule-based in early stages.
 
 ---
 
@@ -84,13 +83,26 @@ NEXT_PUBLIC_API_URL=http://localhost:8000
 ### 2. Start the backend (Docker)
 
 ```bash
-docker-compose up -d
+docker compose up -d --build
 ```
 
-This starts:
+If you previously ran the optional worker (or upgraded from an older compose file), remove stale containers first:
+
+```bash
+docker compose down --remove-orphans
+docker compose up -d --build
+```
+
+This builds the **api** image from `backend/Dockerfile` and starts:
 - **PostgreSQL** on port `5433`
 - **Redis** on port `6379`
 - **FastAPI** on port `8000` (with hot reload)
+
+The **Celery worker** is optional (Step 6) and is not started by default. To include it:
+
+```bash
+docker compose --profile worker up -d --build
+```
 
 Verify the backend is running:
 
@@ -128,6 +140,7 @@ pytest -m cache -v
 pytest -m recommend_cache -v
 pytest -m rate_limit -v
 pytest -m retry -v
+pytest -m enrichment -v
 ```
 
 To measure cache, retry, and rate-limit impact (no Google API key required):
@@ -200,11 +213,45 @@ GET /recommend?mode=work&lat=37.7749&lng=-122.4194&radius=2000&open_now=true
       "price_level": 2,
       "hours": { "weekday_text": [...], "open_now": true },
       "raw_hours": "Monday: 7:00 AM – 6:00 PM\n...",
-      "explanations": []
+      "explanations": ["Within 450 m", "Open now", "Highly rated (4.5)"]
     }
   ]
 }
 ```
+
+### `GET /venues/{provider_id}/profile`
+
+Return (and if needed, compute) heuristic attribute scores for a venue.
+
+**Path parameter:** `provider_id` — Google Places place ID (same as `venues[].provider_id` from `/recommend`).
+
+**Behavior:**
+- On cache miss from `/recommend`, venues are upserted into Postgres in the background.
+- This endpoint fetches review snippets from Google Places, runs keyword heuristics, and upserts a `VenueProfile`.
+- If a profile exists and is younger than the TTL (7 days), returns it without re-fetching reviews.
+
+**Response shape:**
+
+```json
+{
+  "id": "uuid",
+  "venue_id": "uuid",
+  "attribute_scores": {
+    "quiet": 0.67,
+    "laptop_friendly": 0.5,
+    "romantic": 0.33
+  },
+  "evidence_snippets": {
+    "quiet": ["Great spot for studying, very peaceful atmosphere."],
+    "laptop_friendly": ["Reliable wifi and plenty of outlets."]
+  },
+  "embedding_ref": null,
+  "profiled_at": "2026-06-19T12:00:00Z",
+  "expires_at": "2026-06-26T12:00:00Z"
+}
+```
+
+**Canonical attributes:** `quiet`, `noisy`, `laptop_friendly`, `romantic`, `fast_service`, `value` (scores 0–1; omitted when no signal).
 
 ### `GET /test/google-places`
 
@@ -234,11 +281,13 @@ Debug endpoint for raw Google Places integration.
 │   │   │   ├── venue.py          # Venue + VenueProfile
 │   │   │   └── user_event.py     # UserEvent + Mode/EventType enums
 │   │   ├── ranking/              # Mode-specific scoring + explanations (Step 4)
+│   │   ├── text_attributes/      # Keyword heuristics for review inference (Step 5)
+│   │   ├── services/             # Enrichment + venue persistence (Step 5)
 │   │   ├── schemas/              # Pydantic schemas
 │   │   │   ├── venue.py          # VenueCreate / VenueRead
 │   │   │   └── recommend.py      # RecommendRequest, RecommendResponse, VenueCard (incl. distance_m), RecommendMeta
 │   │   └── providers/            # External API providers
-│   │       └── google.py         # Google Places Text Search client (paginated, with fallback)
+│   │       └── google.py         # Google Places Text Search + review/details fetch
 │   ├── alembic/                  # Database migrations
 │   │   └── versions/
 │   ├── scripts/
@@ -248,6 +297,8 @@ Debug endpoint for raw Google Places integration.
 │   │   ├── test_recommend_rate_limit_and_retry.py  # Rate limit, retry, cache hit (markers: rate_limit, retry, recommend_cache)
 │   │   ├── test_google_places.py # Provider + pagination + fallback (marker: provider)
 │   │   ├── test_ranking.py       # Mode-specific ranking + explanations (Step 4)
+│   │   ├── test_text_attributes_heuristics.py  # Review heuristic inference (Step 5)
+│   │   ├── test_enrichment.py    # Profile enrichment + venue upsert (Step 5, marker: enrichment)
 │   │   ├── test_schemas.py       # Schema validation (marker: schemas)
 │   │   └── test_smoke.py         # Health endpoint (marker: smoke)
 │   ├── pyproject.toml           # Pytest markers for test subsets
@@ -403,7 +454,66 @@ The map originally used DOM-based Mapbox markers (one HTML element per venue). T
 
 ### Step 5 — Reviews ingestion + text inference
 
+**Delivered:** Deterministic heuristic enrichment from Google review snippets — no ML. Venues from `/recommend` are persisted to Postgres; profiles are built on demand via the profile endpoint and shown in the detail panel.
+
+- [x] **VenueProfile storage** — Reuses `attribute_scores`, `evidence_snippets`, `profiled_at`, `expires_at` on `venue_profiles` (initial migration).
+- [x] **Review ingestion** — `GooglePlacesClient.fetch_place_reviews()` and `fetch_place_details()` return bounded `ReviewSnippet` texts (reviews + editorial summary, max 10, truncated to 300 chars).
+- [x] **Heuristic pipeline** — `infer_attributes_from_text()` in `backend/app/text_attributes/heuristics.py` scores `quiet`, `noisy`, `laptop_friendly`, `romantic`, `fast_service`, `value` using positive/negative keyword rules.
+- [x] **Enrichment service** — `enrich_venue_profile(provider_id, session)` upserts profiles with 7-day TTL; skips re-inference when fresh.
+- [x] **Venue persistence from `/recommend`** — Background upsert on cache miss via `upsert_venues_from_provider()` so enrichment can find venues without an extra Details call.
+- [x] **Read API** — `GET /venues/{provider_id}/profile` returns `VenueProfileResponse`.
+- [x] **UI** — `VenueDetailPanel` fetches profile and shows “Vibe” tags (score ≥ 40%) with evidence tooltips on hover.
+- [x] **Tests** — `test_text_attributes_heuristics.py` (unit) and `test_enrichment.py` (service-level with mocked provider + Postgres).
+
+**Scoring formula:** `score = pos_count / (pos_count + neg_count + 1)` per attribute. See attribute rules in `backend/app/text_attributes/heuristics.py`.
+
+**Manual test (local):**
+
+```bash
+# 1. Start stack
+docker compose up -d --build
+
+# 2. Run Step 5 tests (requires Postgres on :5433)
+cd backend && python3 -m pytest tests/test_text_attributes_heuristics.py tests/test_enrichment.py -v
+
+# 3. Get a provider_id from /recommend, then fetch profile
+curl -s "http://localhost:8000/recommend?mode=work&lat=37.7749&lng=-122.4194&radius=1000&cache=0" | python3 -c "import sys,json; v=json.load(sys.stdin)['venues'][0]; print(v['provider_id'])"
+curl -s "http://localhost:8000/venues/<provider_id>/profile" | python3 -m json.tool
+```
+
 ### Step 6 — Async jobs + enrichment orchestration
+
+**Delivered:** Celery + Redis background jobs wrap the existing enrichment service. `/recommend` schedules enrichment non-blockingly; job lifecycle is tracked in Postgres with admin visibility.
+
+- [x] **Job model + migration** — `jobs` table with `job_type`, `status`, `attempts`, `idempotency_key`, timestamps; partial unique index on active jobs.
+- [x] **Celery app** — `app/worker/celery_app.py` + `app/worker/tasks.py` with `enrich_venue`, `batch_enrich_area`, `refresh_stale_profiles` tasks.
+- [x] **Job service** — `schedule_enrich_venue()` with Redis enqueue locks, idempotency dedup, fresh-profile skip.
+- [x] **`/recommend` orchestration** — Background scheduling after venue fetch; response unchanged (no profiles on hot path).
+- [x] **Profile endpoint** — Sync enrichment preserved for detail panel UX; also enqueues background job when stale.
+- [x] **Admin API** — `GET /admin/jobs`, `GET /admin/jobs/{id}`, `GET /admin/jobs/summary` (gated by `ADMIN_API_ENABLED`).
+- [x] **Docker worker profile** — `docker compose --profile worker up` starts Celery worker + Beat.
+- [x] **Tests** — `test_jobs.py`, `test_admin_jobs.py`, `test_recommend_enrichment_schedule.py`.
+
+**Manual test (local):**
+
+```bash
+# 1. Start stack with worker
+docker compose --profile worker up -d --build
+
+# 2. Apply migration (if not auto-applied)
+cd backend && alembic upgrade head
+
+# 3. Trigger recommend (schedules jobs)
+curl -s "http://localhost:8000/recommend?mode=work&lat=37.7749&lng=-122.4194&radius=1000&cache=0" > /dev/null
+
+# 4. Check admin
+curl -s "http://localhost:8000/admin/jobs/summary" | python3 -m json.tool
+curl -s "http://localhost:8000/admin/jobs?status=COMPLETED" | python3 -m json.tool
+
+# 5. Profile should be warm on fetch
+curl -s "http://localhost:8000/recommend?mode=work&lat=37.7749&lng=-122.4194&radius=1000&cache=0" | python3 -c "import sys,json; v=json.load(sys.stdin)['venues'][0]; print(v['provider_id'])"
+curl -s "http://localhost:8000/venues/<provider_id>/profile" | python3 -m json.tool
+```
 
 ### Step 7 — Mode-fit ranking + sliders
 

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -13,7 +13,7 @@ from app.config import settings
 from app.db.base import Base
 
 # Import all models so Alembic can detect them
-from app.models import UserEvent, Venue, VenueProfile  # noqa: F401
+from app.models import Job, UserEvent, Venue, VenueProfile  # noqa: F401
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/backend/alembic/versions/a1b2c3d4e5f6_add_jobs_table.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_add_jobs_table.py
@@ -1,0 +1,70 @@
+"""add jobs table
+
+Revision ID: a1b2c3d4e5f6
+Revises: f99aa361bd09
+Create Date: 2026-06-21 12:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "a1b2c3d4e5f6"
+down_revision: str | None = "f99aa361bd09"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "jobs",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("job_type", sa.String(length=50), nullable=False),
+        sa.Column("venue_id", sa.UUID(), nullable=True),
+        sa.Column("provider_id", sa.String(length=255), nullable=True),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("attempts", sa.Integer(), nullable=False),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column("idempotency_key", sa.String(length=512), nullable=False),
+        sa.Column("lock_key", sa.String(length=512), nullable=True),
+        sa.Column("payload", postgresql.JSON(astext_type=sa.Text()), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["venue_id"], ["venues.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_jobs_id"), "jobs", ["id"], unique=False)
+    op.create_index(op.f("ix_jobs_job_type"), "jobs", ["job_type"], unique=False)
+    op.create_index(op.f("ix_jobs_provider_id"), "jobs", ["provider_id"], unique=False)
+    op.create_index(op.f("ix_jobs_status"), "jobs", ["status"], unique=False)
+    op.create_index(op.f("ix_jobs_venue_id"), "jobs", ["venue_id"], unique=False)
+    op.create_index(
+        "ix_jobs_status_job_type_created_at",
+        "jobs",
+        ["status", "job_type", "created_at"],
+        unique=False,
+    )
+    op.create_index(
+        "uq_jobs_active_idempotency_key",
+        "jobs",
+        ["idempotency_key"],
+        unique=True,
+        postgresql_where=sa.text("status IN ('PENDING', 'RUNNING')"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_jobs_active_idempotency_key", table_name="jobs")
+    op.drop_index("ix_jobs_status_job_type_created_at", table_name="jobs")
+    op.drop_index(op.f("ix_jobs_venue_id"), table_name="jobs")
+    op.drop_index(op.f("ix_jobs_status"), table_name="jobs")
+    op.drop_index(op.f("ix_jobs_provider_id"), table_name="jobs")
+    op.drop_index(op.f("ix_jobs_job_type"), table_name="jobs")
+    op.drop_index(op.f("ix_jobs_id"), table_name="jobs")
+    op.drop_table("jobs")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -13,6 +13,16 @@ class Settings(BaseSettings):
     redis_url: str = "redis://localhost:6379/0"
     recommend_cache_ttl_seconds: int = 900  # 15 minutes
 
+    # Celery / async jobs
+    celery_broker_url: str = "redis://localhost:6379/1"
+    celery_result_backend: str | None = "redis://localhost:6379/2"
+    job_lock_ttl_seconds: int = 300
+    enrich_max_retries: int = 3
+    enrich_retry_backoff_base: float = 2.0
+    profile_refresh_interval_hours: int = 6
+    profile_refresh_batch_size: int = 50
+    admin_api_enabled: bool = True
+
     # Google Places API
     google_places_api_key: str = ""
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import math
 import time
+import uuid
 
 import httpx
 from fastapi import Depends, FastAPI, HTTPException, Query, Request, Response
@@ -15,14 +16,50 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.cache import build_recommend_cache_key, get_cached_recommend, set_cached_recommend
 from app.config import settings
-from app.db.session import get_db
+from app.db.session import AsyncSessionLocal, get_db
+from app.models.job import JobStatus, JobType
 from app.models.user_event import Mode
 from app.ranking import score_and_explain
+from app.schemas.job import JobListResponse, JobResponse, JobSummaryResponse
 from app.schemas.recommend import RecommendMeta, RecommendRequest, RecommendResponse, VenueCard
 from app.schemas.venue import VenueCreate, VenueProfileResponse
 
 logger = logging.getLogger(__name__)
 limiter = Limiter(key_func=get_remote_address)
+
+
+async def _persist_venues_background(venues: list[VenueCreate]) -> None:
+    """Best-effort upsert of recommend results so enrichment can find venues in DB."""
+    try:
+        from app.services.venues import upsert_venues_from_provider
+
+        async with AsyncSessionLocal() as session:
+            await upsert_venues_from_provider(session, venues)
+    except Exception as e:
+        logger.warning("Background venue persist failed: %s", e)
+
+
+async def _schedule_enrichment_background(provider_ids: list[str]) -> None:
+    """Best-effort scheduling of background enrichment jobs for recommend results."""
+    try:
+        from redis.asyncio import Redis
+
+        from app.services.jobs import schedule_enrich_for_provider_ids
+
+        redis = Redis.from_url(settings.celery_broker_url)
+        try:
+            async with AsyncSessionLocal() as session:
+                await schedule_enrich_for_provider_ids(provider_ids, session, redis)
+        finally:
+            await redis.aclose()
+    except Exception as e:
+        logger.warning("Background enrichment schedule failed: %s", e)
+
+
+def _require_admin_api() -> None:
+    """Return 404 when admin endpoints are disabled."""
+    if not settings.admin_api_enabled:
+        raise HTTPException(status_code=404, detail="Not found")
 
 
 class ModeSearch:
@@ -161,6 +198,21 @@ app.add_middleware(
 )
 
 
+def _provider_error_response(detail: str, provider_status: int) -> HTTPException:
+    """Map Google Places provider failures to actionable API errors."""
+    if provider_status == 403 or "PERMISSION_DENIED" in detail:
+        return HTTPException(
+            status_code=503,
+            detail=(
+                "Google Places API access denied. Enable 'Places API (New)' in Google Cloud "
+                "Console, enable billing, and ensure GOOGLE_PLACES_API_KEY in .env is valid with "
+                "no referrer/IP restrictions blocking server requests. "
+                "See backend/GOOGLE_PLACES_SETUP.md."
+            ),
+        )
+    return HTTPException(status_code=502, detail=f"Provider error: {detail}")
+
+
 @app.get("/health")
 def health():
     """Health check endpoint."""
@@ -190,16 +242,33 @@ async def get_venue_profile(
     Returns:
         VenueProfileResponse with attribute_scores and evidence_snippets.
     """
+    from redis.asyncio import Redis
+
     from app.services.enrichment import enrich_venue_profile
+    from app.services.jobs import profile_is_fresh_for_provider, schedule_enrich_venue
 
     try:
+        if not await profile_is_fresh_for_provider(session, provider_id):
+            try:
+                redis = Redis.from_url(settings.celery_broker_url)
+                try:
+                    await schedule_enrich_venue(provider_id, session, redis)
+                finally:
+                    await redis.aclose()
+            except Exception as schedule_err:
+                logger.warning(
+                    "Background enrichment schedule failed for profile %s: %s",
+                    provider_id,
+                    schedule_err,
+                )
         return await enrich_venue_profile(provider_id, session)
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
     except httpx.HTTPStatusError as e:
         detail = e.response.text if e.response else str(e)
         logger.error("Provider error enriching venue %s: %s", provider_id, detail)
-        raise HTTPException(status_code=502, detail=f"Provider error: {detail}") from e
+        provider_status = e.response.status_code if e.response else 0
+        raise _provider_error_response(detail, provider_status) from e
     except Exception as e:
         logger.error("Unexpected error enriching venue %s: %s", provider_id, e)
         raise HTTPException(status_code=500, detail="Enrichment failed") from e
@@ -342,6 +411,10 @@ async def recommend(
             # All attempts failed; re-raise the last error.
             raise last_err
         venues = venues_list or []
+        if venues:
+            asyncio.create_task(_persist_venues_background(venues))
+            provider_ids = [v.provider_id for v in venues]
+            asyncio.create_task(_schedule_enrichment_background(provider_ids))
         # Attach real distances, filter to within radius, then optionally to open-now only.
         scored: list[tuple[VenueCreate, float]] = []
         for v in venues:
@@ -386,11 +459,61 @@ async def recommend(
         raise HTTPException(status_code=400, detail=str(e)) from e
     except httpx.HTTPStatusError as e:
         detail = e.response.text if e.response else str(e)
+        provider_status = e.response.status_code if e.response else 0
         logger.error("Provider HTTP error in /recommend: %s", detail)
-        raise HTTPException(
-            status_code=502,
-            detail=f"Provider error: {detail}",
-        ) from e
+        raise _provider_error_response(detail, provider_status) from e
     except Exception as e:
         logger.error("Unexpected error in /recommend: %s", e)
         raise HTTPException(status_code=500, detail=f"Error fetching places: {str(e)}") from e
+
+
+@app.get("/admin/jobs/summary", response_model=JobSummaryResponse)
+async def admin_jobs_summary(session: AsyncSession = Depends(get_db)):
+    """Return job counts grouped by status."""
+    _require_admin_api()
+    from app.services.jobs import get_job_summary
+
+    counts = await get_job_summary(session)
+    return JobSummaryResponse(counts=counts, total=sum(counts.values()))
+
+
+@app.get("/admin/jobs", response_model=JobListResponse)
+async def admin_list_jobs(
+    session: AsyncSession = Depends(get_db),
+    status: JobStatus | None = Query(None, description="Filter by job status"),
+    job_type: JobType | None = Query(None, description="Filter by job type"),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+):
+    """List background jobs with optional filters."""
+    _require_admin_api()
+    from app.services.jobs import list_jobs
+
+    jobs, total = await list_jobs(
+        session,
+        status=status,
+        job_type=job_type,
+        limit=limit,
+        offset=offset,
+    )
+    return JobListResponse(
+        jobs=[JobResponse.model_validate(job) for job in jobs],
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@app.get("/admin/jobs/{job_id}", response_model=JobResponse)
+async def admin_get_job(
+    job_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+):
+    """Return a single background job by ID."""
+    _require_admin_api()
+    from app.services.jobs import get_job_by_id
+
+    job = await get_job_by_id(session, job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return JobResponse.model_validate(job)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,6 +1,7 @@
 """Models package exports."""
 
+from app.models.job import Job, JobStatus, JobType
 from app.models.user_event import UserEvent
 from app.models.venue import Venue, VenueProfile
 
-__all__ = ["Venue", "VenueProfile", "UserEvent"]
+__all__ = ["Job", "JobStatus", "JobType", "Venue", "VenueProfile", "UserEvent"]

--- a/backend/app/models/job.py
+++ b/backend/app/models/job.py
@@ -14,13 +14,13 @@ from sqlalchemy.orm import Mapped, mapped_column
 from app.db.base import Base
 
 
-class JobType(str, enum.Enum):
+class JobType(enum.StrEnum):
     ENRICH_VENUE = "ENRICH_VENUE"
     BATCH_ENRICH_AREA = "BATCH_ENRICH_AREA"
     REFRESH_VENUE = "REFRESH_VENUE"
 
 
-class JobStatus(str, enum.Enum):
+class JobStatus(enum.StrEnum):
     PENDING = "PENDING"
     RUNNING = "RUNNING"
     COMPLETED = "COMPLETED"

--- a/backend/app/models/job.py
+++ b/backend/app/models/job.py
@@ -1,0 +1,68 @@
+"""Background job model for async enrichment orchestration."""
+
+from __future__ import annotations
+
+import enum
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, Text
+from sqlalchemy.dialects.postgresql import JSON, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class JobType(str, enum.Enum):
+    ENRICH_VENUE = "ENRICH_VENUE"
+    BATCH_ENRICH_AREA = "BATCH_ENRICH_AREA"
+    REFRESH_VENUE = "REFRESH_VENUE"
+
+
+class JobStatus(str, enum.Enum):
+    PENDING = "PENDING"
+    RUNNING = "RUNNING"
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
+
+
+class Job(Base):
+    """Tracks async enrichment and batch orchestration jobs."""
+
+    __tablename__ = "jobs"
+    __table_args__ = (
+        Index("ix_jobs_status_job_type_created_at", "status", "job_type", "created_at"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        index=True,
+    )
+    job_type: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    venue_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("venues.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    provider_id: Mapped[str | None] = mapped_column(String(255), nullable=True, index=True)
+    status: Mapped[str] = mapped_column(String(20), nullable=False, index=True, default=JobStatus.PENDING.value)
+    attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    idempotency_key: Mapped[str] = mapped_column(String(512), nullable=False)
+    lock_key: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    payload: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+    )
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    def __repr__(self) -> str:
+        return f"<Job(id={self.id}, type={self.job_type}, status={self.status})>"

--- a/backend/app/schemas/job.py
+++ b/backend/app/schemas/job.py
@@ -1,0 +1,47 @@
+"""Pydantic schemas for job admin API."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.models.job import JobStatus, JobType
+
+
+class JobResponse(BaseModel):
+    """Public representation of a background job."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    job_type: JobType
+    status: JobStatus
+    provider_id: str | None
+    venue_id: UUID | None
+    attempts: int
+    last_error: str | None
+    idempotency_key: str
+    payload: dict[str, Any] | None
+    created_at: datetime
+    updated_at: datetime
+    started_at: datetime | None
+    finished_at: datetime | None
+
+
+class JobListResponse(BaseModel):
+    """Paginated job list."""
+
+    jobs: list[JobResponse]
+    total: int
+    limit: int
+    offset: int
+
+
+class JobSummaryResponse(BaseModel):
+    """Counts grouped by job status."""
+
+    counts: dict[str, int] = Field(default_factory=dict)
+    total: int

--- a/backend/app/services/enrichment.py
+++ b/backend/app/services/enrichment.py
@@ -25,12 +25,10 @@ from sqlalchemy.orm import selectinload
 from app.models.venue import Venue, VenueProfile
 from app.providers.google import GooglePlacesClient
 from app.schemas.venue import VenueProfileResponse
+from app.services.profile_freshness import PROFILE_TTL_DAYS, is_profile_fresh
 from app.text_attributes.heuristics import infer_attributes_from_text
 
 logger = logging.getLogger(__name__)
-
-# Profiles older than this are considered stale and will be re-inferred.
-PROFILE_TTL_DAYS = 7
 
 
 # ---------------------------------------------------------------------------
@@ -42,6 +40,8 @@ async def enrich_venue_profile(
     provider_id: str,
     session: AsyncSession,
     ttl_days: int = PROFILE_TTL_DAYS,
+    client: GooglePlacesClient | None = None,
+    force_refresh: bool = False,
 ) -> VenueProfileResponse:
     """Enrich a venue with heuristic attribute scores derived from its reviews.
 
@@ -61,7 +61,8 @@ async def enrich_venue_profile(
         ValueError: If the place cannot be found via the provider API.
         httpx.HTTPStatusError: If the provider API returns an error.
     """
-    venue = await _get_or_create_venue(provider_id, session)
+    places_client = client or GooglePlacesClient()
+    venue = await _get_or_create_venue(provider_id, session, places_client)
 
     # Re-load with profile relationship to avoid lazy-load issues
     result = await session.execute(
@@ -69,15 +70,14 @@ async def enrich_venue_profile(
     )
     venue = result.scalars().one()
 
-    if _is_fresh(venue.profile, ttl_days):
+    if not force_refresh and _is_fresh(venue.profile, ttl_days):
         logger.debug("enrich_venue_profile(%s): profile is fresh, skipping", provider_id)
         return VenueProfileResponse.model_validate(venue.profile)
 
     logger.info("enrich_venue_profile(%s): enriching venue", provider_id)
 
     # Fetch review snippets from provider
-    client = GooglePlacesClient()
-    snippets = await client.fetch_place_reviews(provider_id)
+    snippets = await places_client.fetch_place_reviews(provider_id)
     texts = [s.text for s in snippets]
 
     # Run heuristic text pipeline
@@ -120,17 +120,18 @@ async def enrich_venue_profile(
 # ---------------------------------------------------------------------------
 
 
-async def _get_or_create_venue(provider_id: str, session: AsyncSession) -> Venue:
+async def _get_or_create_venue(
+    provider_id: str,
+    session: AsyncSession,
+    client: GooglePlacesClient,
+) -> Venue:
     """Return an existing Venue or create one from Google Places Details."""
-    result = await session.execute(
-        select(Venue).where(Venue.provider_id == provider_id)
-    )
+    result = await session.execute(select(Venue).where(Venue.provider_id == provider_id))
     venue = result.scalars().first()
     if venue:
         return venue
 
     # Venue is not in DB yet — fetch basic info from Google Places Details
-    client = GooglePlacesClient()
     venue_create = await client.fetch_place_details(provider_id)
     if not venue_create:
         raise ValueError(f"Place not found in provider: {provider_id}")
@@ -160,11 +161,4 @@ async def _get_or_create_venue(provider_id: str, session: AsyncSession) -> Venue
 
 def _is_fresh(profile: VenueProfile | None, ttl_days: int) -> bool:
     """Return True if the profile exists and was profiled within ttl_days."""
-    if profile is None:
-        return False
-    profiled = profile.profiled_at
-    if profiled is None:
-        return False
-    if profiled.tzinfo is None:
-        profiled = profiled.replace(tzinfo=UTC)
-    return (datetime.now(UTC) - profiled) < timedelta(days=ttl_days)
+    return is_profile_fresh(profile, ttl_days)

--- a/backend/app/services/jobs.py
+++ b/backend/app/services/jobs.py
@@ -1,0 +1,341 @@
+"""Job scheduling, deduplication, and status management."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+import pygeohash
+from redis.asyncio import Redis
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.config import settings
+from app.models.job import Job, JobStatus, JobType
+from app.models.venue import Venue, VenueProfile
+from app.services.profile_freshness import is_profile_fresh
+
+logger = logging.getLogger(__name__)
+
+ACTIVE_STATUSES = {JobStatus.PENDING.value, JobStatus.RUNNING.value}
+
+
+def build_idempotency_key(job_type: JobType, provider_id: str) -> str:
+    """Build a unique idempotency key for venue enrichment jobs."""
+    if job_type in (JobType.ENRICH_VENUE, JobType.REFRESH_VENUE):
+        return f"ENRICH_VENUE:{provider_id}"
+    return f"{job_type.value}:{provider_id}"
+
+
+def build_enqueue_lock_key(idempotency_key: str) -> str:
+    """Redis key used to prevent duplicate enqueue storms."""
+    return f"job:enqueue:{idempotency_key}"
+
+
+async def acquire_enqueue_lock(redis: Redis, lock_key: str, ttl: int | None = None) -> bool:
+    """Acquire a short-lived Redis lock (SET NX EX). Returns True if acquired."""
+    ttl_seconds = ttl if ttl is not None else settings.job_lock_ttl_seconds
+    acquired = await redis.set(lock_key, "1", nx=True, ex=ttl_seconds)
+    return bool(acquired)
+
+
+async def get_active_job_for_provider(
+    session: AsyncSession,
+    provider_id: str,
+    job_type: JobType = JobType.ENRICH_VENUE,
+) -> Job | None:
+    """Return an active job for the provider, if one exists."""
+    idempotency_key = build_idempotency_key(job_type, provider_id)
+    result = await session.execute(
+        select(Job).where(
+            Job.idempotency_key == idempotency_key,
+            Job.status.in_(ACTIVE_STATUSES),
+        )
+    )
+    return result.scalars().first()
+
+
+async def mark_job_retry(
+    session: AsyncSession,
+    job_id: uuid.UUID | str,
+    error: str | None = None,
+) -> Job:
+    """Mark a job for retry — increment attempts and reset to PENDING."""
+    job = await _get_job(session, job_id)
+    now = datetime.now(UTC)
+    job.status = JobStatus.PENDING.value
+    job.attempts += 1
+    job.updated_at = now
+    job.started_at = None
+    if error is not None:
+        job.last_error = error[:2000]
+    await session.commit()
+    await session.refresh(job)
+    return job
+
+
+async def profile_is_fresh_for_provider(session: AsyncSession, provider_id: str) -> bool:
+    """Return True if the venue has a fresh profile."""
+    result = await session.execute(
+        select(VenueProfile)
+        .join(Venue, VenueProfile.venue_id == Venue.id)
+        .where(Venue.provider_id == provider_id)
+        .options(selectinload(VenueProfile.venue))
+    )
+    profile = result.scalars().first()
+    return is_profile_fresh(profile)
+
+
+async def create_or_get_pending_job(
+    session: AsyncSession,
+    *,
+    job_type: JobType,
+    provider_id: str,
+    venue_id: uuid.UUID | None = None,
+    lock_key: str | None = None,
+    payload: dict[str, Any] | None = None,
+) -> tuple[Job, bool]:
+    """Create a PENDING job or return an existing active one.
+
+    Returns (job, created) where created is True when a new row was inserted.
+    """
+    idempotency_key = build_idempotency_key(job_type, provider_id)
+    existing = await get_active_job_for_provider(session, provider_id, job_type)
+    if existing is not None:
+        return existing, False
+
+    now = datetime.now(UTC)
+    job = Job(
+        job_type=job_type.value,
+        provider_id=provider_id,
+        venue_id=venue_id,
+        status=JobStatus.PENDING.value,
+        attempts=0,
+        idempotency_key=idempotency_key,
+        lock_key=lock_key,
+        payload=payload,
+        created_at=now,
+        updated_at=now,
+    )
+    session.add(job)
+    try:
+        await session.flush()
+        return job, True
+    except IntegrityError:
+        await session.rollback()
+        result = await session.execute(
+            select(Job).where(Job.idempotency_key == idempotency_key)
+        )
+        job = result.scalars().one()
+        return job, False
+
+
+async def mark_job_running(session: AsyncSession, job_id: uuid.UUID | str) -> Job:
+    """Transition a job to RUNNING."""
+    job = await _get_job(session, job_id)
+    now = datetime.now(UTC)
+    job.status = JobStatus.RUNNING.value
+    job.started_at = now
+    job.updated_at = now
+    await session.commit()
+    await session.refresh(job)
+    return job
+
+
+async def mark_job_completed(session: AsyncSession, job_id: uuid.UUID | str) -> Job:
+    """Transition a job to COMPLETED."""
+    job = await _get_job(session, job_id)
+    now = datetime.now(UTC)
+    job.status = JobStatus.COMPLETED.value
+    job.finished_at = now
+    job.updated_at = now
+    job.last_error = None
+    await session.commit()
+    await session.refresh(job)
+    return job
+
+
+async def mark_job_failed(
+    session: AsyncSession,
+    job_id: uuid.UUID | str,
+    error: str | None = None,
+    *,
+    increment_attempts: bool = False,
+) -> Job:
+    """Transition a job to FAILED."""
+    job = await _get_job(session, job_id)
+    now = datetime.now(UTC)
+    job.status = JobStatus.FAILED.value
+    job.finished_at = now
+    job.updated_at = now
+    if increment_attempts:
+        job.attempts += 1
+    if error is not None:
+        job.last_error = error[:2000]
+    await session.commit()
+    await session.refresh(job)
+    return job
+
+
+async def schedule_enrich_venue(
+    provider_id: str,
+    session: AsyncSession,
+    redis: Redis,
+    *,
+    force: bool = False,
+) -> Job | None:
+    """Schedule a single ENRICH_VENUE job if not already active or fresh."""
+    if not force and await profile_is_fresh_for_provider(session, provider_id):
+        logger.debug("schedule_enrich_venue(%s): profile fresh, skipping", provider_id)
+        return None
+
+    job_type = JobType.REFRESH_VENUE if force else JobType.ENRICH_VENUE
+    idempotency_key = build_idempotency_key(JobType.ENRICH_VENUE, provider_id)
+    lock_key = build_enqueue_lock_key(idempotency_key)
+
+    if not await acquire_enqueue_lock(redis, lock_key):
+        existing = await get_active_job_for_provider(session, provider_id, job_type)
+        if existing is not None:
+            return existing
+        # Lock held but no active job — another enqueue in progress; skip.
+        return None
+
+    venue_result = await session.execute(select(Venue).where(Venue.provider_id == provider_id))
+    venue = venue_result.scalars().first()
+
+    job, created = await create_or_get_pending_job(
+        session,
+        job_type=job_type,
+        provider_id=provider_id,
+        venue_id=venue.id if venue else None,
+        lock_key=lock_key,
+        payload={"force": force},
+    )
+    await session.commit()
+
+    if created or job.status == JobStatus.PENDING.value:
+        from app.worker.tasks import enrich_venue_task
+
+        enrich_venue_task.delay(str(job.id), provider_id, force)
+        logger.info("Scheduled %s for provider %s (job=%s)", job_type.value, provider_id, job.id)
+
+    return job
+
+
+async def schedule_enrich_for_provider_ids(
+    provider_ids: list[str],
+    session: AsyncSession,
+    redis: Redis,
+    *,
+    force: bool = False,
+) -> int:
+    """Schedule enrichment for multiple provider IDs. Returns count scheduled."""
+    scheduled = 0
+    seen: set[str] = set()
+    for provider_id in provider_ids:
+        if provider_id in seen:
+            continue
+        seen.add(provider_id)
+        job = await schedule_enrich_venue(provider_id, session, redis, force=force)
+        if job is not None:
+            scheduled += 1
+    return scheduled
+
+
+async def list_jobs(
+    session: AsyncSession,
+    *,
+    status: JobStatus | None = None,
+    job_type: JobType | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> tuple[list[Job], int]:
+    """List jobs with optional filters."""
+    query = select(Job)
+    count_query = select(func.count()).select_from(Job)
+
+    if status is not None:
+        query = query.where(Job.status == status.value)
+        count_query = count_query.where(Job.status == status.value)
+    if job_type is not None:
+        query = query.where(Job.job_type == job_type.value)
+        count_query = count_query.where(Job.job_type == job_type.value)
+
+    query = query.order_by(Job.created_at.desc()).limit(limit).offset(offset)
+
+    result = await session.execute(query)
+    jobs = list(result.scalars().all())
+    total_result = await session.execute(count_query)
+    total = int(total_result.scalar_one())
+    return jobs, total
+
+
+async def get_job_by_id(session: AsyncSession, job_id: uuid.UUID) -> Job | None:
+    """Fetch a single job by ID."""
+    result = await session.execute(select(Job).where(Job.id == job_id))
+    return result.scalars().first()
+
+
+async def get_job_summary(session: AsyncSession) -> dict[str, int]:
+    """Return counts grouped by job status."""
+    result = await session.execute(
+        select(Job.status, func.count()).group_by(Job.status)
+    )
+    counts = {status: count for status, count in result.all()}
+    return counts
+
+
+async def find_stale_profile_provider_ids(
+    session: AsyncSession,
+    *,
+    limit: int = 50,
+) -> list[str]:
+    """Return provider IDs for venues with expired or missing profiles."""
+    now = datetime.now(UTC)
+    result = await session.execute(
+        select(Venue.provider_id)
+        .outerjoin(VenueProfile, VenueProfile.venue_id == Venue.id)
+        .where(
+            (VenueProfile.id.is_(None))
+            | (VenueProfile.expires_at.is_(None))
+            | (VenueProfile.expires_at < now)
+        )
+        .limit(limit)
+    )
+    return list(result.scalars().all())
+
+
+async def find_provider_ids_in_tile(
+    session: AsyncSession,
+    tile_id: str,
+    *,
+    limit: int = 50,
+) -> list[str]:
+    """Return provider IDs for venues in a geohash tile lacking fresh profiles."""
+    prefix = tile_id[: len(tile_id)]
+    result = await session.execute(
+        select(Venue.provider_id, Venue.lat, Venue.lng, VenueProfile)
+        .outerjoin(VenueProfile, VenueProfile.venue_id == Venue.id)
+    )
+    provider_ids: list[str] = []
+    for provider_id, lat, lng, profile in result.all():
+        venue_tile = pygeohash.encode(lat, lng, precision=len(prefix))
+        if not venue_tile.startswith(prefix):
+            continue
+        if is_profile_fresh(profile):
+            continue
+        provider_ids.append(provider_id)
+        if len(provider_ids) >= limit:
+            break
+    return provider_ids
+
+
+async def _get_job(session: AsyncSession, job_id: uuid.UUID | str) -> Job:
+    parsed_id = uuid.UUID(str(job_id))
+    result = await session.execute(select(Job).where(Job.id == parsed_id))
+    job = result.scalars().one()
+    return job

--- a/backend/app/services/profile_freshness.py
+++ b/backend/app/services/profile_freshness.py
@@ -1,0 +1,21 @@
+"""Shared profile freshness checks for enrichment and job scheduling."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from app.models.venue import VenueProfile
+
+PROFILE_TTL_DAYS = 7
+
+
+def is_profile_fresh(profile: VenueProfile | None, ttl_days: int = PROFILE_TTL_DAYS) -> bool:
+    """Return True if the profile exists and was profiled within ttl_days."""
+    if profile is None:
+        return False
+    profiled = profile.profiled_at
+    if profiled is None:
+        return False
+    if profiled.tzinfo is None:
+        profiled = profiled.replace(tzinfo=UTC)
+    return (datetime.now(UTC) - profiled) < timedelta(days=ttl_days)

--- a/backend/app/services/venues.py
+++ b/backend/app/services/venues.py
@@ -1,0 +1,78 @@
+"""Venue persistence helpers."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.venue import Venue
+from app.schemas.venue import VenueCreate
+
+logger = logging.getLogger(__name__)
+
+
+async def upsert_venues_from_provider(
+    session: AsyncSession,
+    venues: list[VenueCreate],
+) -> int:
+    """Insert or update venues returned from the provider.
+
+    Called after /recommend cache misses so enrichment can find venues in DB
+    without an extra Place Details call.
+
+    Args:
+        session: Active async SQLAlchemy session.
+        venues: Normalized provider venues from a search response.
+
+    Returns:
+        Number of venues upserted.
+    """
+    if not venues:
+        return 0
+
+    now = datetime.now(UTC)
+    count = 0
+
+    for v in venues:
+        result = await session.execute(select(Venue).where(Venue.provider_id == v.provider_id))
+        existing = result.scalars().first()
+
+        if existing:
+            existing.name = v.name
+            existing.categories = v.categories
+            existing.lat = v.lat
+            existing.lng = v.lng
+            existing.address = v.address
+            existing.rating = v.rating
+            existing.price_level = v.price_level
+            existing.hours = v.hours
+            existing.raw_hours = v.raw_hours
+            existing.last_seen_at = now
+            existing.updated_at = now
+        else:
+            session.add(
+                Venue(
+                    provider_id=v.provider_id,
+                    provider_name=v.provider_name,
+                    name=v.name,
+                    categories=v.categories,
+                    lat=v.lat,
+                    lng=v.lng,
+                    address=v.address,
+                    rating=v.rating,
+                    price_level=v.price_level,
+                    hours=v.hours,
+                    raw_hours=v.raw_hours,
+                    last_seen_at=now,
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
+        count += 1
+
+    await session.commit()
+    logger.debug("upsert_venues_from_provider: upserted %d venues", count)
+    return count

--- a/backend/app/text_attributes/README.md
+++ b/backend/app/text_attributes/README.md
@@ -1,0 +1,37 @@
+# Text Attributes — Heuristic Inference
+
+Keyword/rule-based inference of venue attributes from review snippets. No ML dependencies.
+
+## Public API
+
+```python
+from app.text_attributes import infer_attributes_from_text
+
+scores, evidence = infer_attributes_from_text([
+    "Quiet cafe with great wifi.",
+    "Fast service and good value.",
+])
+```
+
+## Canonical attributes
+
+| Key | Positive signal examples | Negative signal examples |
+|-----|-------------------------|------------------------|
+| `quiet` | quiet, peaceful, calm | loud, noisy, crowded |
+| `noisy` | loud, rowdy, packed | quiet, peaceful, calm |
+| `laptop_friendly` | wifi, outlets, laptop | no wifi, no outlets |
+| `romantic` | romantic, date night, cozy | sports bar, rowdy |
+| `fast_service` | fast service, no wait | slow service, long wait |
+| `value` | good value, affordable | overpriced, not worth |
+
+## Scoring
+
+Per attribute: `score = pos_count / (pos_count + neg_count + 1)`
+
+- Attributes with **no** positive or negative matches are omitted from the output.
+- Negation snippets (e.g. "no wifi") suppress positive hits for that snippet.
+- Up to 3 evidence snippets per attribute (truncated to 160 chars).
+
+## Upgrade path
+
+Replace the body of `infer_attributes_from_text` with an ML classifier while keeping the same return shape. `VenueProfile` remains the storage layer.

--- a/backend/app/text_attributes/heuristics.py
+++ b/backend/app/text_attributes/heuristics.py
@@ -61,6 +61,29 @@ ATTRIBUTE_RULES: dict[str, tuple[list[str], list[str]]] = {
             "deafening",
         ],
     ),
+    "noisy": (
+        [
+            "loud",
+            "noisy",
+            "crowded",
+            "packed",
+            "blasting music",
+            "rowdy",
+            "bustling",
+            "chaotic",
+            "deafening",
+        ],
+        [
+            "quiet",
+            "peaceful",
+            "calm",
+            "tranquil",
+            "serene",
+            "not too loud",
+            "mellow vibe",
+            "low-key",
+        ],
+    ),
     "laptop_friendly": (
         [
             "wifi",

--- a/backend/app/worker/__init__.py
+++ b/backend/app/worker/__init__.py
@@ -1,0 +1,1 @@
+"""Celery worker package."""

--- a/backend/app/worker/celery_app.py
+++ b/backend/app/worker/celery_app.py
@@ -1,0 +1,41 @@
+"""Celery application configuration."""
+
+from celery import Celery
+from celery.schedules import crontab
+
+from app.config import settings
+
+celery_app = Celery("modemap")
+
+celery_config: dict = {
+    "broker_url": settings.celery_broker_url,
+    "task_serializer": "json",
+    "accept_content": ["json"],
+    "result_serializer": "json",
+    "timezone": "UTC",
+    "enable_utc": True,
+    "task_acks_late": True,
+    "task_reject_on_worker_lost": True,
+    "worker_prefetch_multiplier": 1,
+    "task_default_queue": "enrichment",
+    "task_routes": {
+        "enrich_venue": {"queue": "enrichment"},
+        "batch_enrich_area": {"queue": "enrichment"},
+        "refresh_stale_profiles": {"queue": "enrichment"},
+    },
+    "beat_schedule": {
+        "refresh-stale-profiles": {
+            "task": "refresh_stale_profiles",
+            "schedule": crontab(minute=0, hour=f"*/{settings.profile_refresh_interval_hours}"),
+        },
+    },
+}
+
+if settings.celery_result_backend:
+    celery_config["result_backend"] = settings.celery_result_backend
+
+celery_app.config_from_object(celery_config)
+celery_app.autodiscover_tasks(["app.worker"])
+
+# Import tasks so they register when the worker starts.
+from app.worker import tasks as _tasks  # noqa: E402, F401

--- a/backend/app/worker/tasks.py
+++ b/backend/app/worker/tasks.py
@@ -1,0 +1,142 @@
+"""Celery tasks for async venue enrichment."""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import logging
+import uuid
+
+import httpx
+from celery.exceptions import MaxRetriesExceededError
+from redis.asyncio import Redis
+
+from app.config import settings
+from app.db.session import AsyncSessionLocal
+from app.services.enrichment import enrich_venue_profile
+from app.services.jobs import (
+    mark_job_completed,
+    mark_job_failed,
+    mark_job_retry,
+    mark_job_running,
+    schedule_enrich_for_provider_ids,
+)
+from app.worker.celery_app import celery_app
+
+logger = logging.getLogger(__name__)
+
+
+def _run_async(coro) -> None:
+    """Run an async coroutine from Celery's synchronous worker context."""
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        asyncio.run(coro)
+        return
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(asyncio.run, coro)
+        future.result()
+
+
+def _is_retryable(exc: BaseException) -> bool:
+    """Return True for transient provider errors worth retrying."""
+    if isinstance(exc, httpx.TransportError):
+        return True
+    if isinstance(exc, httpx.HTTPStatusError):
+        status = exc.response.status_code if exc.response else 0
+        return status >= 500 or status == 429
+    return False
+
+
+@celery_app.task(bind=True, name="enrich_venue", max_retries=settings.enrich_max_retries)
+def enrich_venue_task(self, job_id: str, provider_id: str, force: bool = False) -> None:
+    """Run venue enrichment in a background worker."""
+    try:
+        _run_async(_execute_enrich(self, job_id, provider_id, force))
+    except MaxRetriesExceededError:
+        logger.error("enrich_venue_task exhausted retries for job=%s provider=%s", job_id, provider_id)
+
+
+async def _execute_enrich(task, job_id: str, provider_id: str, force: bool) -> None:
+    async with AsyncSessionLocal() as session:
+        await mark_job_running(session, job_id)
+        try:
+            await enrich_venue_profile(
+                provider_id,
+                session,
+                force_refresh=force,
+            )
+            await mark_job_completed(session, job_id)
+        except Exception as exc:
+            retryable = _is_retryable(exc)
+            if retryable and task.request.retries < settings.enrich_max_retries:
+                await mark_job_retry(session, job_id, str(exc))
+                countdown = settings.enrich_retry_backoff_base ** task.request.retries
+                raise task.retry(exc=exc, countdown=countdown) from exc
+
+            await mark_job_failed(session, job_id, str(exc), increment_attempts=True)
+            if retryable:
+                raise
+            logger.warning(
+                "enrich_venue_task permanent failure job=%s provider=%s: %s",
+                job_id,
+                provider_id,
+                exc,
+            )
+
+
+@celery_app.task(name="batch_enrich_area")
+def batch_enrich_area_task(job_id: str, tile_id: str, limit: int = 50) -> None:
+    """Enqueue ENRICH_VENUE jobs for venues in a geohash tile."""
+    _run_async(_execute_batch_enrich(job_id, tile_id, limit))
+
+
+async def _execute_batch_enrich(job_id: str, tile_id: str, limit: int) -> None:
+    from app.services.jobs import (
+        find_provider_ids_in_tile,
+        get_job_by_id,
+        mark_job_completed,
+        mark_job_running,
+    )
+
+    async with AsyncSessionLocal() as session:
+        await mark_job_running(session, job_id)
+        redis = Redis.from_url(settings.celery_broker_url)
+        try:
+            provider_ids = await find_provider_ids_in_tile(session, tile_id, limit=limit)
+            scheduled = await schedule_enrich_for_provider_ids(provider_ids, session, redis)
+            job = await get_job_by_id(session, uuid.UUID(job_id))
+            if job is not None:
+                job.payload = {
+                    **(job.payload or {}),
+                    "tile_id": tile_id,
+                    "scheduled_count": scheduled,
+                    "provider_ids_found": len(provider_ids),
+                }
+                await session.commit()
+            await mark_job_completed(session, job_id)
+        finally:
+            await redis.aclose()
+
+
+@celery_app.task(name="refresh_stale_profiles")
+def refresh_stale_profiles_task() -> None:
+    """Beat-triggered sweep of expired venue profiles."""
+    _run_async(_execute_refresh_stale_profiles())
+
+
+async def _execute_refresh_stale_profiles() -> None:
+    from app.services.jobs import find_stale_profile_provider_ids
+
+    async with AsyncSessionLocal() as session:
+        redis = Redis.from_url(settings.celery_broker_url)
+        try:
+            provider_ids = await find_stale_profile_provider_ids(
+                session,
+                limit=settings.profile_refresh_batch_size,
+            )
+            await schedule_enrich_for_provider_ids(provider_ids, session, redis, force=True)
+            logger.info("refresh_stale_profiles scheduled %d jobs", len(provider_ids))
+        finally:
+            await redis.aclose()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -31,4 +31,6 @@ markers = [
   "smoke: very fast smoke tests",
   "rate_limit: slowapi rate limiting tests",
   "retry: provider retry/backoff tests",
+  "enrichment: venue profile enrichment and persistence tests",
+  "jobs: async job scheduling, celery tasks, and admin API tests",
 ]

--- a/backend/tests/test_admin_jobs.py
+++ b/backend/tests/test_admin_jobs.py
@@ -1,0 +1,114 @@
+"""Tests for admin job endpoints."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+
+import pytest
+import pytest_asyncio
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.db.session import get_db
+from app.main import app
+from app.models.job import Job, JobStatus, JobType
+from app.models.venue import Venue
+from app.services.jobs import build_idempotency_key
+
+pytestmark = pytest.mark.jobs
+
+
+@pytest.fixture
+def admin_client(test_session):
+    async def override_get_db() -> AsyncGenerator[AsyncSession, None]:
+        yield test_session
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def seeded_jobs(test_session):
+    venue = Venue(
+        provider_id="ChIJ_admin_test",
+        provider_name="google",
+        name="Admin Test Cafe",
+        categories=["cafe"],
+        lat=37.77,
+        lng=-122.42,
+        address="123 Admin St",
+        rating=4.0,
+        price_level=2,
+        hours={"open_now": True},
+        last_seen_at=datetime.now(UTC),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    test_session.add(venue)
+    await test_session.commit()
+    await test_session.refresh(venue)
+
+    now = datetime.now(UTC)
+    pending = Job(
+        job_type=JobType.ENRICH_VENUE.value,
+        provider_id="ChIJ_admin_test",
+        venue_id=venue.id,
+        status=JobStatus.PENDING.value,
+        attempts=0,
+        idempotency_key=build_idempotency_key(JobType.ENRICH_VENUE, "ChIJ_admin_test"),
+        created_at=now,
+        updated_at=now,
+    )
+    completed = Job(
+        job_type=JobType.ENRICH_VENUE.value,
+        provider_id="ChIJ_admin_done",
+        status=JobStatus.COMPLETED.value,
+        attempts=1,
+        idempotency_key=build_idempotency_key(JobType.ENRICH_VENUE, "ChIJ_admin_done"),
+        created_at=now,
+        updated_at=now,
+        finished_at=now,
+    )
+    test_session.add_all([pending, completed])
+    await test_session.commit()
+    await test_session.refresh(pending)
+    return pending, completed
+
+
+def test_admin_jobs_summary(seeded_jobs, admin_client, monkeypatch):
+    monkeypatch.setattr(settings, "admin_api_enabled", True)
+    resp = admin_client.get("/admin/jobs/summary")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] >= 2
+    assert body["counts"]["PENDING"] >= 1
+    assert body["counts"]["COMPLETED"] >= 1
+
+
+def test_admin_list_jobs_filtered_by_status(seeded_jobs, admin_client, monkeypatch):
+    monkeypatch.setattr(settings, "admin_api_enabled", True)
+    resp = admin_client.get("/admin/jobs", params={"status": "PENDING"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] >= 1
+    assert all(job["status"] == "PENDING" for job in body["jobs"])
+
+
+def test_admin_get_job_by_id(seeded_jobs, admin_client, monkeypatch):
+    pending, _ = seeded_jobs
+    monkeypatch.setattr(settings, "admin_api_enabled", True)
+    resp = admin_client.get(f"/admin/jobs/{pending.id}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == str(pending.id)
+    assert body["provider_id"] == "ChIJ_admin_test"
+
+
+def test_admin_disabled_returns_404(admin_client, monkeypatch):
+    monkeypatch.setattr(settings, "admin_api_enabled", False)
+    resp = admin_client.get("/admin/jobs")
+    assert resp.status_code == 404

--- a/backend/tests/test_enrichment.py
+++ b/backend/tests/test_enrichment.py
@@ -1,0 +1,156 @@
+"""Service-level tests for venue enrichment and persistence."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from app.models.venue import Venue, VenueProfile
+from app.providers.google import ReviewSnippet
+from app.schemas.venue import VenueCreate
+from app.services.enrichment import enrich_venue_profile
+from app.services.venues import upsert_venues_from_provider
+
+pytestmark = pytest.mark.enrichment
+
+
+def _venue_create(provider_id: str = "ChIJ_test_place") -> VenueCreate:
+    return VenueCreate(
+        provider_id=provider_id,
+        provider_name="google",
+        name="Test Cafe",
+        categories=["cafe"],
+        lat=37.77,
+        lng=-122.42,
+        address="123 Test St",
+        rating=4.2,
+        price_level=2,
+        hours={"open_now": True},
+        raw_hours=None,
+    )
+
+
+class FakeGoogleClient:
+    """Minimal Google Places client stub for enrichment tests."""
+
+    def __init__(
+        self,
+        reviews: list[ReviewSnippet] | None = None,
+        details: VenueCreate | None = None,
+    ):
+        self.reviews = reviews or [
+            ReviewSnippet(text="Quiet cafe with great wifi and fast service."),
+            ReviewSnippet(text="Good value and romantic atmosphere for date night."),
+        ]
+        self.details = details or _venue_create()
+
+    async def fetch_place_reviews(self, provider_place_id: str, max_snippets: int = 10):
+        return self.reviews[:max_snippets]
+
+    async def fetch_place_details(self, provider_place_id: str):
+        return self.details
+
+
+@pytest_asyncio.fixture
+async def sample_venue(test_session):
+    """Persist a venue row for enrichment tests."""
+    venue = Venue(
+        provider_id="ChIJ_test_place",
+        provider_name="google",
+        name="Test Cafe",
+        categories=["cafe"],
+        lat=37.77,
+        lng=-122.42,
+        address="123 Test St",
+        rating=4.2,
+        price_level=2,
+        hours={"open_now": True},
+        last_seen_at=datetime.now(UTC),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    test_session.add(venue)
+    await test_session.commit()
+    await test_session.refresh(venue)
+    return venue
+
+
+@pytest.mark.asyncio
+async def test_enrich_creates_profile_from_reviews(test_session, sample_venue):
+    client = FakeGoogleClient()
+    result = await enrich_venue_profile(
+        sample_venue.provider_id,
+        test_session,
+        client=client,  # type: ignore[arg-type]
+    )
+
+    assert result.venue_id == sample_venue.id
+    assert result.attribute_scores
+    assert "quiet" in result.attribute_scores or "laptop_friendly" in result.attribute_scores
+    assert result.evidence_snippets
+
+    row = await test_session.execute(
+        select(VenueProfile).where(VenueProfile.venue_id == sample_venue.id)
+    )
+    profile = row.scalars().one()
+    assert profile.attribute_scores == result.attribute_scores
+
+
+@pytest.mark.asyncio
+async def test_enrich_skips_fresh_profile(test_session, sample_venue):
+    fresh = VenueProfile(
+        venue_id=sample_venue.id,
+        attribute_scores={"quiet": 0.9},
+        evidence_snippets={"quiet": ["Already profiled"]},
+        profiled_at=datetime.now(UTC),
+        expires_at=datetime.now(UTC) + timedelta(days=7),
+    )
+    test_session.add(fresh)
+    await test_session.commit()
+
+    client = FakeGoogleClient()
+    client.fetch_place_reviews = AsyncMock(return_value=[ReviewSnippet(text="should not run")])
+
+    result = await enrich_venue_profile(
+        sample_venue.provider_id,
+        test_session,
+        client=client,  # type: ignore[arg-type]
+    )
+
+    assert result.attribute_scores == {"quiet": 0.9}
+    client.fetch_place_reviews.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_enrich_creates_venue_when_missing(test_session):
+    client = FakeGoogleClient(details=_venue_create("ChIJ_new_place"))
+    result = await enrich_venue_profile(
+        "ChIJ_new_place",
+        test_session,
+        client=client,  # type: ignore[arg-type]
+    )
+
+    row = await test_session.execute(select(Venue).where(Venue.provider_id == "ChIJ_new_place"))
+    venue = row.scalars().one()
+    assert venue.name == "Test Cafe"
+    assert result.venue_id == venue.id
+    assert result.attribute_scores
+
+
+@pytest.mark.asyncio
+async def test_upsert_venues_inserts_and_updates(test_session):
+    v1 = _venue_create("ChIJ_upsert_a")
+    inserted = await upsert_venues_from_provider(test_session, [v1])
+    assert inserted == 1
+
+    v2 = v1.model_copy(update={"name": "Updated Cafe"})
+    updated = await upsert_venues_from_provider(test_session, [v2])
+    assert updated == 1
+
+    row = await test_session.execute(select(Venue).where(Venue.provider_id == "ChIJ_upsert_a"))
+    venue = row.scalars().one()
+    assert venue.name == "Updated Cafe"

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -1,0 +1,257 @@
+"""Unit tests for job scheduling and celery tasks."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from app.models.job import Job, JobStatus, JobType
+from app.models.venue import Venue, VenueProfile
+from app.services.jobs import (
+    acquire_enqueue_lock,
+    build_idempotency_key,
+    mark_job_completed,
+    mark_job_running,
+    schedule_enrich_for_provider_ids,
+    schedule_enrich_venue,
+)
+from app.worker.celery_app import celery_app
+
+pytestmark = pytest.mark.jobs
+
+
+class FakeRedis:
+    """Minimal async Redis stub for enqueue lock tests."""
+
+    def __init__(self) -> None:
+        self._keys: dict[str, str] = {}
+
+    async def set(self, key: str, value: str, nx: bool = False, ex: int | None = None) -> bool:
+        if nx and key in self._keys:
+            return False
+        self._keys[key] = value
+        return True
+
+    async def aclose(self) -> None:
+        return None
+
+
+@pytest.fixture(autouse=True)
+def celery_eager():
+    """Run Celery tasks synchronously in tests."""
+    celery_app.conf.task_always_eager = True
+    celery_app.conf.task_eager_propagates = True
+    yield
+    celery_app.conf.task_always_eager = False
+    celery_app.conf.task_eager_propagates = False
+
+
+@pytest_asyncio.fixture
+async def sample_venue(test_session):
+    venue = Venue(
+        provider_id="ChIJ_jobs_test",
+        provider_name="google",
+        name="Jobs Test Cafe",
+        categories=["cafe"],
+        lat=37.77,
+        lng=-122.42,
+        address="123 Jobs St",
+        rating=4.0,
+        price_level=2,
+        hours={"open_now": True},
+        last_seen_at=datetime.now(UTC),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    test_session.add(venue)
+    await test_session.commit()
+    await test_session.refresh(venue)
+    return venue
+
+
+@pytest.mark.asyncio
+async def test_idempotency_key_prevents_duplicate_pending_jobs(test_session, sample_venue):
+    redis = FakeRedis()
+    with patch("app.worker.tasks.enrich_venue_task.delay") as mock_delay:
+        job1 = await schedule_enrich_venue("ChIJ_jobs_test", test_session, redis)
+        job2 = await schedule_enrich_venue("ChIJ_jobs_test", test_session, redis)
+
+    assert job1 is not None
+    assert job2 is not None
+    assert job1.id == job2.id
+    assert mock_delay.call_count == 1
+
+    result = await test_session.execute(select(Job))
+    jobs = result.scalars().all()
+    assert len(jobs) == 1
+    assert jobs[0].status == JobStatus.PENDING.value
+
+
+@pytest.mark.asyncio
+async def test_skips_fresh_profile(test_session, sample_venue):
+    now = datetime.now(UTC)
+    profile = VenueProfile(
+        venue_id=sample_venue.id,
+        attribute_scores={"quiet": 0.8},
+        evidence_snippets={"quiet": ["Very quiet"]},
+        profiled_at=now,
+        expires_at=now + timedelta(days=7),
+    )
+    test_session.add(profile)
+    await test_session.commit()
+
+    redis = FakeRedis()
+    with patch("app.worker.tasks.enrich_venue_task.delay"):
+        job = await schedule_enrich_venue("ChIJ_jobs_test", test_session, redis)
+
+    assert job is None
+    result = await test_session.execute(select(Job))
+    assert len(result.scalars().all()) == 0
+
+
+@pytest.mark.asyncio
+async def test_mark_job_lifecycle(test_session, sample_venue):
+    job = Job(
+        job_type=JobType.ENRICH_VENUE.value,
+        provider_id="ChIJ_jobs_test",
+        venue_id=sample_venue.id,
+        status=JobStatus.PENDING.value,
+        attempts=0,
+        idempotency_key=build_idempotency_key(JobType.ENRICH_VENUE, "ChIJ_jobs_test"),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    test_session.add(job)
+    await test_session.commit()
+    await test_session.refresh(job)
+
+    await mark_job_running(test_session, job.id)
+    await test_session.refresh(job)
+    assert job.status == JobStatus.RUNNING.value
+    assert job.started_at is not None
+
+    await mark_job_completed(test_session, job.id)
+    await test_session.refresh(job)
+    assert job.status == JobStatus.COMPLETED.value
+    assert job.finished_at is not None
+
+
+@pytest.mark.asyncio
+async def test_enqueue_lock_prevents_duplicate_acquire():
+    redis = FakeRedis()
+    assert await acquire_enqueue_lock(redis, "lock:test", ttl=60) is True
+    assert await acquire_enqueue_lock(redis, "lock:test", ttl=60) is False
+
+
+@pytest.mark.asyncio
+async def test_enrich_venue_task_success(test_session, sample_venue, monkeypatch):
+    job = Job(
+        job_type=JobType.ENRICH_VENUE.value,
+        provider_id="ChIJ_jobs_test",
+        venue_id=sample_venue.id,
+        status=JobStatus.PENDING.value,
+        attempts=0,
+        idempotency_key=build_idempotency_key(JobType.ENRICH_VENUE, "ChIJ_jobs_test"),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    test_session.add(job)
+    await test_session.commit()
+    job_id = job.id
+
+    class SessionCtx:
+        def __init__(self, session):
+            self._session = session
+
+        async def __aenter__(self):
+            return self._session
+
+        async def __aexit__(self, *args):
+            return None
+
+    class FakeTask:
+        class request:
+            retries = 0
+
+        def retry(self, *args, **kwargs):
+            raise AssertionError("retry should not be called")
+
+    monkeypatch.setattr("app.worker.tasks.AsyncSessionLocal", lambda: SessionCtx(test_session))
+
+    mock_response = AsyncMock()
+    with patch("app.worker.tasks.enrich_venue_profile", new=AsyncMock(return_value=mock_response)):
+        from app.worker.tasks import _execute_enrich
+
+        await _execute_enrich(FakeTask(), str(job_id), "ChIJ_jobs_test", False)
+
+    result = await test_session.execute(select(Job).where(Job.id == job_id))
+    job = result.scalars().one()
+    assert job.status == JobStatus.COMPLETED.value
+
+
+@pytest.mark.asyncio
+async def test_enrich_venue_task_permanent_failure(test_session, sample_venue, monkeypatch):
+    job = Job(
+        job_type=JobType.ENRICH_VENUE.value,
+        provider_id="ChIJ_jobs_test",
+        venue_id=sample_venue.id,
+        status=JobStatus.PENDING.value,
+        attempts=0,
+        idempotency_key=build_idempotency_key(JobType.ENRICH_VENUE, "ChIJ_jobs_test"),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    test_session.add(job)
+    await test_session.commit()
+    job_id = job.id
+
+    class SessionCtx:
+        def __init__(self, session):
+            self._session = session
+
+        async def __aenter__(self):
+            return self._session
+
+        async def __aexit__(self, *args):
+            return None
+
+    class FakeTask:
+        class request:
+            retries = 0
+
+        def retry(self, *args, **kwargs):
+            raise AssertionError("retry should not be called")
+
+    monkeypatch.setattr("app.worker.tasks.AsyncSessionLocal", lambda: SessionCtx(test_session))
+
+    with patch(
+        "app.worker.tasks.enrich_venue_profile",
+        new=AsyncMock(side_effect=ValueError("Place not found")),
+    ):
+        from app.worker.tasks import _execute_enrich
+
+        await _execute_enrich(FakeTask(), str(job_id), "ChIJ_jobs_test", False)
+
+    result = await test_session.execute(select(Job).where(Job.id == job_id))
+    job = result.scalars().one()
+    assert job.status == JobStatus.FAILED.value
+    assert job.attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_schedule_enrich_for_provider_ids_deduplicates(test_session, sample_venue):
+    redis = FakeRedis()
+    with patch("app.worker.tasks.enrich_venue_task.delay"):
+        count = await schedule_enrich_for_provider_ids(
+            ["ChIJ_jobs_test", "ChIJ_jobs_test"],
+            test_session,
+            redis,
+        )
+
+    assert count == 1
+    result = await test_session.execute(select(Job))
+    assert len(result.scalars().all()) == 1

--- a/backend/tests/test_recommend_enrichment_schedule.py
+++ b/backend/tests/test_recommend_enrichment_schedule.py
@@ -1,0 +1,125 @@
+"""Integration tests for /recommend enrichment scheduling."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.schemas.venue import VenueCreate
+
+pytestmark = pytest.mark.jobs
+
+
+def _make_recommend_url(**overrides: str) -> str:
+    params = {
+        "mode": "work",
+        "lat": "37.7749",
+        "lng": "-122.4194",
+        "radius": "1000",
+        "open_now": "false",
+        "max_results": "2",
+        "cache": "0",
+    }
+    params.update(overrides)
+    query = "&".join(f"{k}={v}" for k, v in params.items())
+    return f"/recommend?{query}"
+
+
+@pytest.fixture(autouse=True)
+def disable_limiter():
+    app.state.limiter.enabled = False
+    yield
+    app.state.limiter.enabled = True
+
+
+def test_recommend_schedules_enrichment(monkeypatch):
+    venues = [
+        VenueCreate(
+            provider_id="ChIJ_schedule_a",
+            provider_name="google",
+            name="Venue A",
+            categories=["cafe"],
+            lat=37.7749,
+            lng=-122.4194,
+            address="A St",
+            rating=4.5,
+            price_level=2,
+            hours={"open_now": True},
+            raw_hours=None,
+        ),
+        VenueCreate(
+            provider_id="ChIJ_schedule_b",
+            provider_name="google",
+            name="Venue B",
+            categories=["cafe"],
+            lat=37.7750,
+            lng=-122.4195,
+            address="B St",
+            rating=4.3,
+            price_level=1,
+            hours={"open_now": True},
+            raw_hours=None,
+        ),
+    ]
+
+    class DummyClient:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        async def text_search(self, *args, **kwargs):
+            return venues
+
+    scheduled_ids: list[str] = []
+
+    async def capture_schedule(provider_ids: list[str]) -> None:
+        scheduled_ids.extend(provider_ids)
+
+    monkeypatch.setattr("app.providers.GooglePlacesClient", DummyClient)
+    monkeypatch.setattr("app.main._schedule_enrichment_background", capture_schedule)
+    monkeypatch.setattr("app.main._persist_venues_background", AsyncMock())
+
+    with TestClient(app) as client:
+        resp = client.get(_make_recommend_url())
+
+    assert resp.status_code == 200
+    assert "ChIJ_schedule_a" in scheduled_ids
+    assert "ChIJ_schedule_b" in scheduled_ids
+
+
+def test_recommend_response_unaffected_by_scheduling(monkeypatch):
+    venues = [
+        VenueCreate(
+            provider_id="ChIJ_fast",
+            provider_name="google",
+            name="Fast Venue",
+            categories=["cafe"],
+            lat=37.7749,
+            lng=-122.4194,
+            address="Fast St",
+            rating=4.8,
+            price_level=2,
+            hours={"open_now": True},
+            raw_hours=None,
+        ),
+    ]
+
+    class DummyClient:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        async def text_search(self, *args, **kwargs):
+            return venues
+
+    monkeypatch.setattr("app.providers.GooglePlacesClient", DummyClient)
+    monkeypatch.setattr("app.main._schedule_enrichment_background", AsyncMock())
+    monkeypatch.setattr("app.main._persist_venues_background", AsyncMock())
+
+    client = TestClient(app)
+    resp = client.get(_make_recommend_url())
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["venues"][0]["provider_id"] == "ChIJ_fast"
+    assert "attribute_scores" not in body["venues"][0]

--- a/backend/tests/test_text_attributes_heuristics.py
+++ b/backend/tests/test_text_attributes_heuristics.py
@@ -51,8 +51,27 @@ def test_scores_in_range():
 
 def test_all_canonical_attributes_covered():
     """ATTRIBUTE_RULES contains all expected attributes."""
-    expected = {"quiet", "laptop_friendly", "romantic", "fast_service", "value"}
+    expected = {"quiet", "noisy", "laptop_friendly", "romantic", "fast_service", "value"}
     assert set(ATTRIBUTE_RULES.keys()) == expected
+
+
+# ---------------------------------------------------------------------------
+# noisy
+# ---------------------------------------------------------------------------
+
+
+def test_noisy_raises_on_positive_patterns():
+    texts = ["So loud and noisy, very crowded.", "Blasting music and rowdy crowd."]
+    scores, _ = infer_attributes_from_text(texts)
+    assert "noisy" in scores
+    assert scores["noisy"] > 0.4
+
+
+def test_noisy_lowers_on_quiet_patterns():
+    texts = ["Very quiet and peaceful.", "Calm and tranquil atmosphere."]
+    scores, _ = infer_attributes_from_text(texts)
+    assert "noisy" in scores
+    assert scores["noisy"] < 0.4
 
 
 # ---------------------------------------------------------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,11 +31,15 @@ services:
     build:
       context: .
       dockerfile: backend/Dockerfile
+    image: modemap-api:latest
+    pull_policy: build
     env_file:
       - .env
     environment:
       DATABASE_URL: postgresql+psycopg://modemap:modemap@postgres:5432/modemap
       REDIS_URL: redis://redis:6379/0
+      CELERY_BROKER_URL: redis://redis:6379/1
+      CELERY_RESULT_BACKEND: redis://redis:6379/2
       ENV: dev
     ports:
       - "8000:8000"
@@ -47,19 +51,23 @@ services:
       redis:
         condition: service_healthy
     command: >
-      uvicorn app.main:app
-      --host 0.0.0.0
-      --port 8000
-      --reload
+      sh -c "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload"
 
-  # Optional for now (turn on when you add Celery tasks)
+  # Optional — enable with: docker compose --profile worker up -d (Step 6)
   worker:
+    profiles: ["worker"]
     build:
       context: .
       dockerfile: backend/Dockerfile
+    image: modemap-worker:latest
+    pull_policy: build
+    env_file:
+      - .env
     environment:
       DATABASE_URL: postgresql+psycopg://modemap:modemap@postgres:5432/modemap
       REDIS_URL: redis://redis:6379/0
+      CELERY_BROKER_URL: redis://redis:6379/1
+      CELERY_RESULT_BACKEND: redis://redis:6379/2
       ENV: dev
     volumes:
       - ./backend:/app
@@ -69,7 +77,32 @@ services:
       redis:
         condition: service_healthy
     command: >
-      celery -A app.worker.celery_app worker -l INFO
+      celery -A app.worker.celery_app worker -l INFO -Q enrichment
+
+  beat:
+    profiles: ["worker"]
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    image: modemap-beat:latest
+    pull_policy: build
+    env_file:
+      - .env
+    environment:
+      DATABASE_URL: postgresql+psycopg://modemap:modemap@postgres:5432/modemap
+      REDIS_URL: redis://redis:6379/0
+      CELERY_BROKER_URL: redis://redis:6379/1
+      CELERY_RESULT_BACKEND: redis://redis:6379/2
+      ENV: dev
+    volumes:
+      - ./backend:/app
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    command: >
+      celery -A app.worker.celery_app beat -l INFO
 
 volumes:
   postgres_data:

--- a/frontend/components/VenueDetailPanel.tsx
+++ b/frontend/components/VenueDetailPanel.tsx
@@ -49,6 +49,7 @@ function DirectionsLink({ lat, lng, name }: { lat: number; lng: number; name: st
 /** Display label + icon for each canonical attribute key. */
 const ATTRIBUTE_META: Record<string, { label: string; icon: string }> = {
   quiet: { label: "Quiet", icon: "🤫" },
+  noisy: { label: "Lively", icon: "🔊" },
   laptop_friendly: { label: "Laptop-friendly", icon: "💻" },
   romantic: { label: "Romantic", icon: "✨" },
   fast_service: { label: "Quick service", icon: "⚡" },

--- a/frontend/hooks/useRecommend.ts
+++ b/frontend/hooks/useRecommend.ts
@@ -52,6 +52,9 @@ export function useRecommend() {
   }, [loadRecommend]);
 
   const onVenueSelect = useCallback((venue: RecommendVenue) => {
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
     setSelectedVenueId((prev) => {
       const next = prev === venue.id ? null : venue.id;
       if (next) setSnap(0.5);

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -2,6 +2,18 @@ export type Mode = "work" | "date" | "quick_bite" | "budget";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL;
 
+function formatApiError(status: number, body: string): string {
+    try {
+        const parsed = JSON.parse(body) as { detail?: string };
+        if (typeof parsed.detail === "string" && parsed.detail.length > 0) {
+            return parsed.detail;
+        }
+    } catch {
+        // fall through to generic message
+    }
+    return `API error: ${status}`;
+}
+
 export interface Venue {
     id: string;
     provider_id: string;
@@ -147,7 +159,9 @@ export async function recommend(params: RecommendParams): Promise<RecommendRespo
 
     const response = await fetch(url.toString());
     if (!response.ok) {
-        throw new Error(`API error: ${response.status} ${response.statusText}`);
+        const errBody = await response.text().catch(() => "");
+        const userMessage = formatApiError(response.status, errBody);
+        throw new Error(userMessage);
     }
 
     const data = (await response.json()) as RecommendResponse;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@types/mapbox-gl": "^3.4.1",
         "mapbox-gl": "^3.18.0",
-        "next": "16.1.4",
+        "next": "^16.2.9",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "vaul": "^1.1.2"
@@ -39,12 +39,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.28.6.tgz",
-      "integrity": "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -53,29 +54,31 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.6.tgz",
-      "integrity": "sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.6.tgz",
-      "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/generator": "^7.28.6",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -92,13 +95,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.6.tgz",
-      "integrity": "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -108,13 +112,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -124,36 +129,39 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -163,52 +171,57 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.6.tgz",
-      "integrity": "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.6"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -218,31 +231,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.6.tgz",
-      "integrity": "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/generator": "^7.28.6",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.6",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -250,13 +265,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.6.tgz",
-      "integrity": "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1019,9 +1035,10 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.4.tgz",
-      "integrity": "sha512-gkrXnZyxPUy0Gg6SrPQPccbNVLSP3vmW8LU5dwEttEEC1RwDivk8w4O+sZIjFvPrSICXyhQDCG+y3VmjlJf+9A=="
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.9.tgz",
+      "integrity": "sha512-ki5VxxXfzD/9TDe13wyeTKIjQTAwBVpnr8KhRDUr8ltMUq1/NBpWNT5tiPoxiGl+PHM4X2ahSOiPk6iAimIzPg==",
+      "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "16.1.4",
@@ -1033,12 +1050,13 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.4.tgz",
-      "integrity": "sha512-T8atLKuvk13XQUdVLCv1ZzMPgLPW0+DWWbHSQXs0/3TjPrKNxTmUIhOEaoEyl3Z82k8h/gEtqyuoZGv6+Ugawg==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.9.tgz",
+      "integrity": "sha512-HkfxNYUCmcct0Xsqib5KxqMSHV4AHJq857BNRchyBDs4YS19aHzVfn1kDuBYKqLLQBjXgnkIsjV2Kd4d2wzYhw==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -1048,12 +1066,13 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.4.tgz",
-      "integrity": "sha512-AKC/qVjUGUQDSPI6gESTx0xOnOPQ5gttogNS3o6bA83yiaSZJek0Am5yXy82F1KcZCx3DdOwdGPZpQCluonuxg==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.9.tgz",
+      "integrity": "sha512-7IAtK4MeybpqRV9GRABWEhJ62mOS+rzWOzOTFie4cSEtm12xsoOMJRcECoZx3FHPzFAqN/IJtHqWAFOLfl152w==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -1063,12 +1082,16 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.4.tgz",
-      "integrity": "sha512-POQ65+pnYOkZNdngWfMEt7r53bzWiKkVNbjpmCt1Zb3V6lxJNXSsjwRuTQ8P/kguxDC8LRkqaL3vvsFrce4dMQ==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.9.tgz",
+      "integrity": "sha512-hBD75iWpUtkL9SmQmcRhmLomn9jgkPzCEkbOcLgHymPEKzv+6ONy13RRiIEz/iEObjkS2Jlb5gYS2XGoS3X4rw==",
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1078,12 +1101,16 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.4.tgz",
-      "integrity": "sha512-3Wm0zGYVCs6qDFAiSSDL+Z+r46EdtCv/2l+UlIdMbAq9hPJBvGu/rZOeuvCaIUjbArkmXac8HnTyQPJFzFWA0Q==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.9.tgz",
+      "integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1093,12 +1120,16 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.4.tgz",
-      "integrity": "sha512-lWAYAezFinaJiD5Gv8HDidtsZdT3CDaCeqoPoJjeB57OqzvMajpIhlZFce5sCAH6VuX4mdkxCRqecCJFwfm2nQ==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.9.tgz",
+      "integrity": "sha512-xm0HfRNX+UkH4R3c18ynswjj5o5uEj/7iI9p9omdtTSIsRCzQqkGMA+10nzJ4EHnYC3as65IMhbbl5fWRUWHYg==",
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1108,12 +1139,16 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.4.tgz",
-      "integrity": "sha512-fHaIpT7x4gA6VQbdEpYUXRGyge/YbRrkG6DXM60XiBqDM2g2NcrsQaIuj375egnGFkJow4RHacgBOEsHfGbiUw==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.9.tgz",
+      "integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1123,12 +1158,13 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.4.tgz",
-      "integrity": "sha512-MCrXxrTSE7jPN1NyXJr39E+aNFBrQZtO154LoCz7n99FuKqJDekgxipoodLNWdQP7/DZ5tKMc/efybx1l159hw==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.9.tgz",
+      "integrity": "sha512-hzQpKZvw8rAwI6A2uQh6SacCSvNAXaIkPNsWwzqqfRiIMiXMfH936skDhz1OO6KpvdKkJrgHHtqQOq5PIXOvdQ==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1138,12 +1174,13 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.4.tgz",
-      "integrity": "sha512-JSVlm9MDhmTXw/sO2PE/MRj+G6XOSMZB+BcZ0a7d6KwVFZVpkHcb2okyoYFBaco6LeiL53BBklRlOrDDbOeE5w==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.9.tgz",
+      "integrity": "sha512-qr2VL3Ce5QrwgO2yh1ujSBawrimjVKX8FGF/cOynmdYKJY0BdHpGVNIRK1tqONB10Vkm25Ub1BD2bkjWs4+96w==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -2054,21 +2091,23 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -2401,10 +2440,11 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2664,18 +2704,23 @@
       "dev": true
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.17",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.17.tgz",
-      "integrity": "sha512-agD0MgJFUP/4nvjqzIB29zRPUuCF7Ge6mEv9s8dHrtYD7QWXRcx75rOADE/d5ah1NI+0vkDl0yorDd5U852IQQ==",
+      "version": "2.10.38",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
+      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
+      "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2694,9 +2739,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -2712,12 +2757,13 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2783,9 +2829,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001765",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001765.tgz",
-      "integrity": "sha512-LWcNtSyZrakjECqmpP4qdg0MMGdN368D7X8XvvAqOcqMv0RxnlqVKZl2V6/mBR68oYMxOZPLw/gO7DuisMHUvQ==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "funding": [
         {
           "type": "opencollective",
@@ -2799,7 +2845,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -3042,10 +3089,11 @@
       "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.267",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
-      "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
-      "dev": true
+      "version": "1.5.376",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.376.tgz",
+      "integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -3240,6 +3288,7 @@
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -3768,10 +3817,11 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -4574,10 +4624,21 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -4590,6 +4651,7 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -4974,6 +5036,7 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -5068,10 +5131,11 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -5100,15 +5164,16 @@
       "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw=="
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.14",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.14.tgz",
+      "integrity": "sha512-U9kYi5bpVMEI31yC8iw4bJJp0avcHXA0W8/wNfLfnvJYzihQo2ZRPYPvpAAd570HAcCBjCTN7vnr+v4StKl1IQ==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -5138,13 +5203,14 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.1.4.tgz",
-      "integrity": "sha512-gKSecROqisnV7Buen5BfjmXAm7Xlpx9o2ueVQRo5DxQcjC8d330dOM1xiGWc2k3Dcnz0In3VybyRPOsudwgiqQ==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.9.tgz",
+      "integrity": "sha512-MEOJiq/UvuezAdqVSceHbqDgZt1kDw2tpGVOlsdIoJsQdbN2JY2hpVG4xnXGkbdJUOEWhnRfiu/O4Hpc9Juwww==",
+      "license": "MIT",
       "dependencies": {
-        "@next/env": "16.1.4",
+        "@next/env": "16.2.9",
         "@swc/helpers": "0.5.15",
-        "baseline-browser-mapping": "^2.8.3",
+        "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
         "styled-jsx": "5.1.6"
@@ -5156,15 +5222,15 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.1.4",
-        "@next/swc-darwin-x64": "16.1.4",
-        "@next/swc-linux-arm64-gnu": "16.1.4",
-        "@next/swc-linux-arm64-musl": "16.1.4",
-        "@next/swc-linux-x64-gnu": "16.1.4",
-        "@next/swc-linux-x64-musl": "16.1.4",
-        "@next/swc-win32-arm64-msvc": "16.1.4",
-        "@next/swc-win32-x64-msvc": "16.1.4",
-        "sharp": "^0.34.4"
+        "@next/swc-darwin-arm64": "16.2.9",
+        "@next/swc-darwin-x64": "16.2.9",
+        "@next/swc-linux-arm64-gnu": "16.2.9",
+        "@next/swc-linux-arm64-musl": "16.2.9",
+        "@next/swc-linux-x64-gnu": "16.2.9",
+        "@next/swc-linux-x64-musl": "16.2.9",
+        "@next/swc-win32-arm64-msvc": "16.2.9",
+        "@next/swc-win32-x64-msvc": "16.2.9",
+        "sharp": "^0.34.5"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -5217,10 +5283,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
-      "dev": true
+      "version": "2.0.48",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
+      "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -5454,10 +5524,11 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -5475,9 +5546,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -5493,8 +5564,9 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5528,9 +5600,10 @@
       }
     },
     "node_modules/protocol-buffers-schema": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -6311,10 +6384,11 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -6579,6 +6653,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "escalade": "^3.2.0",
         "picocolors": "^1.1.1"
@@ -6765,7 +6840,8 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@types/mapbox-gl": "^3.4.1",
     "mapbox-gl": "^3.18.0",
-    "next": "16.1.4",
+    "next": "^16.2.9",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "vaul": "^1.1.2"

--- a/scripts/debug_compose_images.py
+++ b/scripts/debug_compose_images.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Debug helper: log docker compose image/build state to session log."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from pathlib import Path
+
+LOG_PATH = Path(__file__).resolve().parents[1] / ".cursor" / "debug-6e709b.log"
+SESSION = "6e709b"
+
+
+def log(hypothesis_id: str, location: str, message: str, data: dict) -> None:
+    entry = {
+        "sessionId": SESSION,
+        "runId": "post-fix",
+        "hypothesisId": hypothesis_id,
+        "location": location,
+        "message": message,
+        "data": data,
+        "timestamp": int(time.time() * 1000),
+    }
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+def run(cmd: list[str]) -> str:
+    return subprocess.run(cmd, capture_output=True, text=True, check=False).stdout.strip()
+
+
+def main() -> None:
+    services = run(["docker", "compose", "config", "--services"]).splitlines()
+    images_out = run(["docker", "compose", "images", "--format", "json"])
+    ps_out = run(["docker", "compose", "ps", "-a", "--format", "json"])
+
+    built_services = {"api", "worker"}
+    pulled_services = {"postgres", "redis"}
+
+    for svc in services:
+        has_build = svc in built_services
+        log(
+            "A",
+            "scripts/debug_compose_images.py:service",
+            "compose service config",
+            {"service": svc, "expects_local_build": has_build, "expects_pull_only": svc in pulled_services},
+        )
+
+    # Hypothesis A: up -d without --build leaves stale container images
+    for line in images_out.splitlines():
+        if not line.strip():
+            continue
+        parsed = json.loads(line)
+        records = parsed if isinstance(parsed, list) else [parsed]
+        for img in records:
+            if not isinstance(img, dict):
+                continue
+            log(
+                "A",
+                "scripts/debug_compose_images.py:images",
+                "compose image record",
+                {
+                    "container": img.get("Container"),
+                    "repository": img.get("Repository"),
+                    "createdSince": img.get("CreatedSince"),
+                    "id": img.get("ID"),
+                },
+            )
+
+    # Hypothesis B/C: worker exits because celery app missing
+    for line in ps_out.splitlines():
+        if not line.strip():
+            continue
+        row = json.loads(line)
+        if row.get("Service") == "worker":
+            log(
+                "C",
+                "scripts/debug_compose_images.py:worker_ps",
+                "worker container status",
+                {"state": row.get("State"), "status": row.get("Status"), "image": row.get("Image")},
+            )
+        if row.get("Service") == "api":
+            log(
+                "B",
+                "scripts/debug_compose_images.py:api_ps",
+                "api container status",
+                {"state": row.get("State"), "status": row.get("Status"), "image": row.get("Image")},
+            )
+
+    worker_logs = run(["docker", "compose", "logs", "worker", "--tail", "5"])
+    log(
+        "C",
+        "scripts/debug_compose_images.py:worker_logs",
+        "worker recent logs",
+        {"tail": worker_logs[-500:] if worker_logs else ""},
+    )
+
+    images_cmd = run(["docker", "compose", "images"])
+    log(
+        "D",
+        "scripts/debug_compose_images.py:compose_images",
+        "docker compose images result",
+        {
+            "ok": "Error response from daemon" not in images_cmd,
+            "output": images_cmd[:500] if images_cmd else "",
+        },
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add Celery background job orchestration for venue enrichment: `jobs` table, idempotent scheduling, Redis locks, worker/beat compose profile, and admin endpoints (`/admin/jobs`, summary, detail).
- Wire `/recommend` to schedule enrichment non-blockingly; keep sync enrichment on profile fetch with best-effort background scheduling.
- Complete Step 5 follow-through: venue persistence helper, enrichment/profile tests, heuristics docs, and detail panel profile fetch.
- Fix mobile UX: blur filter focus on venue select to avoid Vaul `aria-hidden` warnings; auto-run Alembic migrations on API container start.

## Test plan
- [ ] `docker compose up -d --build` and `docker compose --profile worker up -d --build`
- [ ] `cd backend && python3 -m pytest tests/test_jobs.py tests/test_admin_jobs.py tests/test_recommend_enrichment_schedule.py tests/test_enrichment.py -v`
- [ ] `curl "http://localhost:8000/recommend?mode=work&lat=37.7749&lng=-122.4194&radius=1000&cache=0"` returns venues
- [ ] Open a venue detail panel — profile loads (200, Vibe tags when enriched)
- [ ] `curl "http://localhost:8000/admin/jobs/summary"` returns job counts
- [ ] Mobile: select venue after adjusting radius slider — no `aria-hidden` console warning


Made with [Cursor](https://cursor.com)